### PR TITLE
Add scripts for running other simulators against msprime

### DIFF
--- a/evaluation/Makefile
+++ b/evaluation/Makefile
@@ -1,0 +1,18 @@
+all: sims data plots
+
+.PHONY: sims data plots
+
+sims:
+	pip install -r requirements.txt
+	make -C sims
+
+data:
+	mkdir -p data
+	python3 generate_performance_data.py
+
+plots:
+	python3 plot_data.py data
+
+clean:
+	make -C sims clean
+	rm -fR data

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,32 @@
+This directory contains scripts to automatically install
+and benchmark existing simulation tools against msprime. These
+tools include:
+
+- ms
+- msms
+- scrm
+- discoal
+- ARGON
+
+To install and build the simulators, run:
+```
+make sims
+```
+This also installs the version of msprime specified in
+`requirements.txt`
+
+The `generate_performance_data.py` script runs comparisons of the
+standard coalescent, DTWF, SMC approximation, and selective sweeps.
+To generate performance data for a particular model, run
+```
+python generate_performance_data.py <model>
+```
+To generate data for all models, run
+```
+make data
+```
+
+To plot the data from all simulations, run
+```
+make plots
+```

--- a/evaluation/generate_performance_data.py
+++ b/evaluation/generate_performance_data.py
@@ -1,0 +1,194 @@
+import subprocess
+import sys
+import time
+
+import msprime
+
+REPLICATES = 1
+
+Ne = 1e4
+mu = 1e-9
+r = 1e-8
+
+def run_all():
+    run_standard_coalescent()
+    run_dtwf()
+    run_smc()
+    run_sweep()
+
+
+def run_standard_coalescent():
+    L = mb(1)
+    sample_sizes = range(1000, 10000 + 1, 1000)
+
+    def ms(sample_size):
+        return ms_run(sample_size, L)
+    def msms(sample_size):
+        return msms_run(sample_size, L)
+    def msp(sample_size):
+        return msp_run(sample_size=sample_size, length=L)
+
+    create_data(sample_sizes,
+                [ms, msms, msp],
+                ["ms", "msms", "msprime"],
+                "coalescent")
+
+
+def run_dtwf():
+    L = mb(1)
+    sample_sizes = range(1000, 10000 + 1, 1000)
+
+    def argon(sample_size):
+        return argon_run(sample_size, Ne, L)
+    def msp(sample_size):
+        return msp_run(sample_size=sample_size, length=L, Ne=Ne, model="dtwf")
+
+    create_data(sample_sizes, [msp, argon], ["msprime", "argon"], "dtwf")
+
+
+def run_smc():
+    L = mb(10)
+
+    sample_sizes = range(10000, 20000 + 1, 1000)
+    def scrm(sample_size):
+        return scrm_run(sample_size, L)
+    def msprime_exact(sample_size):
+        return msp_run(sample_size=sample_size, length=L)
+    def msprime_smc(sample_size):
+        return msp_run(sample_size=sample_size, length=L, model="smc")
+
+    create_data(sample_sizes,
+                [scrm, msprime_exact, msprime_smc],
+                ["scrm", "msprime", "msprime_smc"],
+                "smc")
+
+
+# TODO Set up sweep parameters.
+def run_sweep():
+    L = mb(1)
+
+    sample_sizes = range(1000, 15000 + 1, 1000)
+
+    def msms(sample_size):
+        return msms_run(sample_size, L)
+    def discoal(sample_size):
+        return discoal_run(sample_size, L)
+    def msp(sample_size):
+        return msp_run(sample_size=sample_size, length=L)
+
+    create_data(sample_sizes,
+                [msms, discoal, msp],
+                ["msms", "discoal", "msprime"],
+                "sweep")
+
+
+def ms_run(sample_size, L):
+    args = ms_style_args(sample_size, L)
+    exec_cli("./sims/ms", args)
+
+
+def argon_run(sample_size, Ne, L):
+    length_mb = L / mb(1)
+    # ARGON assumes a haploid Ne whereas msprime uses diploid
+    haploid_ne = 2 * int(Ne)
+    args = (
+        f"-N {haploid_ne} -pop 1 {sample_size} "
+        f"-size {length_mb} -rec {r} -quiet -screen"
+    )
+
+    for _ in range(REPLICATES):
+        exec_jar("sims/ARGON.jar", args)
+
+
+def scrm_run(sample_size, L):
+    ms_args = ms_style_args(sample_size, L)
+    scrm_args = "-l 0"
+    args = ms_args + " " + scrm_args
+    exec_cli("./sims/scrm", args)
+
+
+def msms_run(sample_size, L):
+    ms_args = ms_style_args(sample_size, L)
+    args = f"-N {Ne} -ms {ms_args}"
+    exec_jar("sims/msms.jar", args)
+
+
+def discoal_run(sample_size, L):
+    ms_args = ms_style_args(sample_size, L)
+    args = ms_args + " " + f"{int(L)}"
+    exec_cli("./sims/discoal", args)
+
+
+def msp_run(**kwargs):
+    if "Ne" not in kwargs:
+        kwargs["Ne"] = Ne
+    if "recombination_rate" not in kwargs:
+        kwargs["recombination_rate"] = r
+    kwargs["num_replicates"] = REPLICATES
+
+    replicates = msprime.simulate(**kwargs)
+    for ts in replicates:
+        pass
+
+
+def exec_cli(command, args_str):
+    arg_list = [command] + args_str.split()
+    print(" ".join(arg_list))
+    subprocess.call(arg_list, stdout=subprocess.DEVNULL)
+
+
+def exec_jar(jar_path, sim_args_str):
+    args = f"-jar {jar_path} {sim_args_str}"
+    exec_cli("java", args)
+
+
+def ms_style_args(sample_size, L):
+    rho = 4 * Ne * r * L
+    return f"{sample_size} {REPLICATES} -t 10 -r {rho} {int(L)}"
+
+
+def create_data(sample_sizes, tools, tool_names, fname):
+    runtimes = run_sims(sample_sizes, tools, tool_names)
+    with open(f"data/{fname}.csv", "w") as f:
+        f.write(f"sample_size,tool,time\n")
+        for sample_size, runtime_row in zip(sample_sizes, runtimes):
+            for tool_name, tool_time in zip(tool_names, runtime_row):
+                row = f"{sample_size},{tool_name},{tool_time}\n"
+                f.write(row)
+        f.close()
+
+
+def run_sims(sample_sizes, tools, tool_names):
+    runtimes = []
+    for sample_size in sample_sizes:
+        times = []
+        for tool, name in zip(tools, tool_names):
+            print(f"Running {name} on {sample_size} samples...")
+            times.append(time_tool(tool, sample_size))
+        runtimes.append(times)
+    return runtimes
+
+
+def time_tool(tool, sample_size):
+    start = time.time()
+    tool(sample_size)
+    end = time.time()
+    return (end - start) / REPLICATES
+
+
+def mb(L):
+    return L * 1e6
+
+
+if __name__ == "__main__":
+    if "hudson" in sys.argv:
+        run_standard_coalescent()
+    if "dtwf" in sys.argv:
+        run_dtwf()
+    if "smc" in sys.argv:
+        run_smc()
+    if "sweep" in sys.argv:
+        run_sweep()
+
+    if len(sys.argv) == 1:
+        run_all()

--- a/evaluation/plot_data.py
+++ b/evaluation/plot_data.py
@@ -1,0 +1,65 @@
+import os
+import sys
+
+import seaborn as sns
+import pandas as pd
+import matplotlib.pyplot as plt
+
+panels = [["coalescent", "dtwf"],
+          ["smc", "sweep"]]
+
+palette = {
+           "ms": "#F7C362",
+           "msprime": "#2E8CB9",
+           "msms": "#8DA470",
+           "discoal": "#30908E",
+           "argon": "#Df4D47",
+           "msprime_smc": "#66A9FF",
+           "scrm": "#9E5De8",
+          }
+
+params = {'xtick.labelsize': 9,
+          'ytick.labelsize': 9}
+
+def plot_all(data_dir):
+    sns.set(style="darkgrid")
+    plt.rcParams.update(params)
+
+    rows = len(panels)
+    cols = len(panels[0])
+    fig, axes = plt.subplots(rows, cols, squeeze=False)
+
+    for row in range(rows):
+        for col in range(cols):
+            sim = panels[row][col]
+            data = load(f"{data_dir}/{sim}")
+
+            ax = axes[row][col]
+            sns.lineplot(x="sample_size", y="time", hue="tool", palette=palette,
+                         data=data, ax=ax)
+            remove_subplot_legend_title(ax);
+            ax.set_title(sim)
+            ax.set_xlabel("Sample Size" if row > 0 else "")
+            ax.set_ylabel("Time (s)" if col == 0 else "")
+
+    save(fig)
+
+def remove_subplot_legend_title(ax):
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(handles=handles[1:], labels=labels[1:])
+
+def load(sim_path):
+    return pd.read_csv(f"{sim_path}.csv")
+
+def save(fig):
+    plt.tight_layout()
+    fig.savefig(get_output_filename())
+
+def get_output_filename():
+    basedir = "plots"
+    if not os.path.exists(basedir):
+        os.mkdir(basedir)
+    return os.path.join(basedir, "plot.png")
+
+if __name__ == "__main__":
+    plot_all(sys.argv[1])

--- a/evaluation/requirements.txt
+++ b/evaluation/requirements.txt
@@ -1,0 +1,2 @@
+git+git://github.com/tskit-dev/msprime
+seaborn==0.10.0

--- a/evaluation/sims/Makefile
+++ b/evaluation/sims/Makefile
@@ -1,0 +1,29 @@
+all: ms msms scrm discoal argon
+
+ms:
+	make -C msdir
+	cp msdir/ms ./
+
+msms:
+	wget https://www.mabs.at/ewing/msms/msms3.2rc-b163.zip
+	unzip msms3.2rc-b163.zip
+	cp msms/lib/msms.jar ./
+
+scrm:
+	wget https://github.com/scrm/scrm/releases/download/v1.7.2/scrm-src.tar.gz
+	tar -xf scrm-src.tar.gz
+	cd scrm-1.7.2 && ./configure && make
+	cp scrm-1.7.2/scrm ./
+
+discoal:
+	wget https://github.com/kern-lab/discoal/archive/v0.1.4.tar.gz
+	tar -xf v0.1.4.tar.gz
+	cd discoal-0.1.4/ && make 
+	cp discoal-0.1.4/discoal ./
+
+argon:
+	git clone https://github.com/pierpal/ARGON.git
+	cp ARGON/ARGON.0.1.jar ./ARGON.jar
+
+clean:
+	rm -fR ms scrm* discoal* v0* ARGON* msms*

--- a/evaluation/sims/msdir/Makefile
+++ b/evaluation/sims/msdir/Makefile
@@ -1,0 +1,8 @@
+CFLAGS=-ansi -ggdb -Wno-unused-result -Wno-return-type
+SRC=ms.c streec.c rand1.c
+
+ms: ${SRC} 
+	gcc ${CFLAGS} -o ms ${SRC} -lm
+
+clean:
+	rm -f ms

--- a/evaluation/sims/msdir/ms.c
+++ b/evaluation/sims/msdir/ms.c
@@ -1,0 +1,1123 @@
+/***** ms.c     ************************************************
+*
+*       Generates samples of gametes ( theta given or fixed number 
+*						of segregating sites.)
+*	Usage is shown by typing ms without arguments.   
+        usage: ms nsam howmany  -t  theta  [options]
+		or
+	       ms nsam howmany -s segsites  [options] 
+
+	   nsam is the number of gametes per sample.
+	   howmany is the number of samples to produce.
+	   With -t the numbers of segregating sites will randomly vary 
+		from one sample to the next.
+	   with -s segsites,  the number of segregating sites will be
+		segsites in each sample.
+
+           Other options: See msdoc.pdf or after downloading and compiling, type ms<CR>.
+
+
+*	  Arguments of the options are explained here:
+
+           npop:  Number of subpopulations which make up the total population
+           ni:  the sample size from the i th subpopulation (all must be 
+		specified.) The output will have the gametes in order such that
+		the first n1 gametes are from the first island, the next n2 are
+		from the second island, etc.
+           nsites: number of sites between which recombination can occur.
+           theta: 4No times the neutral mutation rate 
+           rho: recombination rate between ends of segment times 4No
+	   f: ratio of conversion rate to recombination rate. (Wiuf and Hein model.)
+	   track_len:  mean length of conversion track in units of sites.  The 
+		       total number of sites is nsites, specified with the -r option.
+           mig_rate: migration rate: the fraction of each subpop made up of
+                 migrants times 4No. 
+           howmany: howmany samples to generate.
+
+	Note:  In the above definition, No is the total diploid population if
+		npop is one, otherwise, No is the diploid population size of each
+		subpopulation. 
+	A seed file called "seedms" will be created  if it doesn't exist. The
+		seed(s) in this file will be modified by the program. 
+		So subsequent runs
+		will produce new output.  The initial contents of seedms will be
+		printed on the second line of the output.
+        Output consists of one line with the command line arguments and one
+	 	line with the seed(s).
+		The samples appear sequentially following that line.
+		Each sample begins with "//", then the number of segregating sites, the positions
+		of the segregating sites (on a scale of 0.0 - 1.0). On the following
+		lines are the sampled gametes, with mutants alleles represented as
+		ones and ancestral alleles as zeros.
+	To compile:  cc -o ms  ms.c  streec.c  rand1.c -lm
+		or:  cc -o ms ms.c streec.c rand2.c -lm
+	 (Of course, gcc would be used instead of cc on some machines.  And -O3 or 
+		some other optimization switches might be usefully employed with some 
+		compilers.) ( rand1.c uses drand48(), whereas rand2.c uses rand() ).
+
+*
+*   Modifications made to combine ms and mss on 25 Feb 2001
+*	Modifications to command line options to use switches  25 Feb 2001
+*	Modifications to add // before each sample  25 Feb 2001
+	Modifications to add gene conversion 5 Mar 2001
+	Added demographic options -d  13 Mar 2001
+	Changed ran1() to use rand(). Changed seed i/o to accomodate this change. 20 April.
+	Changed cleftr() to check for zero rand() .13 June 2001
+	Move seed stuff to subroutine seedit()  11 July 2001
+	Modified streec.c to handle zero length demographic intervals 9 Aug 2001
+	Corrected problem with negative growth rates (Thanks to D. Posada and C. Wiuf) 13 May 2002
+	Changed sample_stats.c to output thetah - pi rather than pi - thetah.  March 8 2003.
+	Changed many command line options, allowing arbitrary migration matrix, and subpopulation
+	   sizes.  Also allows parameters to come from a file. Option to output trees.  Option to
+	   split and join subpopulations.   March 8, 2003. (Old versions saved in msold.tar ).
+	!!! Fixed bug in -en option.  Earlier versions may have produced garbage when -en ... used. 9 Dec 2003
+	Fixed bug which resulted in incorrect results for the case where
+             rho = 0.0 and gene conversion rate > 0.0. This case was not handled
+	    correctly in early versions of the program. 5 Apr 2004.  (Thanks to
+	    Vincent Plagnol for pointing out this problem.) 
+	Fixed bug in prtree().  Earlier versions may have produced garbage when the -T option was used.
+		 1 Jul 2004.
+	Fixed bug in -e. options that caused problems with -f option  13 Aug 2004.
+	Fixed bug in -es option, which was a problem when used with -eG. (Thanks again to V. Plagnol.) 6 Nov. 2004
+	Added -F option:  -F minfreq  produces output with sites with minor allele freq < minfreq filtered out.  11 Nov. 2004.
+	Fixed bug in streec.c (isseg() ).  Bug caused segmentation fault, crash on some machines. (Thanks
+	    to Melissa Jane Todd-Hubisz for finding and reporting this bug.)
+	Added -seeds option 4 Nov 2006
+	Added "tbs" arguments feature 4 Nov 2006
+	Added -L option.  10 May 2007
+	Changed -ej option to set Mki = 0 pastward of the ej event.  See msdoc.pdf.  May 19 2007.
+	fixed bug with memory allocation when using -I option. This caused problems expecially on Windows
+          machines.  Thanks to several people, including Vitor Sousa and Stephane De Mita for help on this one.
+          Oct. 17, 2007.
+     Modified pickb() and pickbmf() to eliminate rare occurrence of fixed mutations Thanks to J. Liechty and K. Thornton. 4 Feb 2010.
+	Added -p n  switch to allow position output to be higher precision.  10 Nov 2012.
+     Changed spot from int to long in the function re().  29 July 2013.  ( Thanks to Yuri D'Elia for this suggestion.)
+      Changed function definitions, and misc other things to comply with c99
+     requirements.  4 Mar 2014.
+***************************************************************************/
+
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <assert.h>
+#include <string.h>
+#include "ms.h"
+
+#define SITESINC 10 
+
+unsigned maxsites = SITESINC ;
+
+
+struct segl {
+	int beg;
+	struct node *ptree;
+	int next;
+	};
+
+double *posit ;
+double *agevec ;
+double alleleage ;
+double segfac ;
+int count, ntbs, nseeds ;
+struct params pars ;	
+
+    int
+main(int argc, char *argv[])
+{
+	int i, k, howmany, segsites , afreq;
+	char **list, **cmatrix(), **tbsparamstrs ;
+	FILE *pf, *fopen() ;
+	double probss, tmrca, ttot ;
+	void seedit( const char * ) ;
+	void getpars( int argc, char *argv[], int *howmany )  ;
+	int gensam( char **list, double *probss, double *ptmrca, double *pttot ) ;
+
+
+	ntbs = 0 ;   /* these next few lines are for reading in parameters from a file (for each sample) */
+	tbsparamstrs = (char **)malloc( argc*sizeof(char *) ) ;
+
+	for( i=0; i<argc; i++) printf("%s ",argv[i]);
+	for( i =0; i<argc; i++) tbsparamstrs[i] = (char *)malloc(30*sizeof(char) ) ;
+	for( i = 1; i<argc ; i++)
+			if( strcmp( argv[i],"tbs") == 0 )  argv[i] = tbsparamstrs[ ntbs++] ;
+	
+	count=0;
+
+	if( ntbs > 0 )  for( k=0; k<ntbs; k++)  scanf(" %s", tbsparamstrs[k] );
+	getpars( argc, argv, &howmany) ;   /* results are stored in global variable, pars */
+	
+	if( !pars.commandlineseedflag ) seedit( "s");
+	pf = stdout ;
+
+	if( pars.mp.segsitesin ==  0 ) {
+	     list = cmatrix(pars.cp.nsam,maxsites+1);
+        posit = (double *)malloc( (unsigned)( maxsites*sizeof( double)) ) ;
+        agevec = (double *)malloc( (unsigned)( maxsites*sizeof( double)) ) ;
+	}
+	else {
+	     list = cmatrix(pars.cp.nsam, pars.mp.segsitesin+1 ) ;
+        posit = (double *)malloc( (unsigned)( pars.mp.segsitesin*sizeof( double)) ) ;
+        agevec = (double *)malloc( (unsigned)( pars.mp.segsitesin*sizeof( double)) ) ;
+	     if( pars.mp.theta > 0.0 ){
+		    segfac = 1.0 ;
+		    for(  i= pars.mp.segsitesin; i > 1; i--) segfac *= i ;
+		 }
+	}
+
+    while( howmany-count++ ) {
+	   if( (ntbs > 0) && (count >1 ) ){
+	         for( k=0; k<ntbs; k++){ 
+			    if( scanf(" %s", tbsparamstrs[k]) == EOF ){
+			       if( !pars.commandlineseedflag ) seedit( "end" );
+				   exit(0);
+				}
+			 }
+			 getpars( argc, argv, &howmany) ;
+	   }
+	   
+       fprintf(pf,"\n//");
+	   if( ntbs >0 ){
+			for(k=0; k< ntbs; k++) printf("\t%s", tbsparamstrs[k] ) ;
+		}
+		printf("\n");
+        segsites = gensam( list, &probss, &tmrca, &ttot ) ; 
+  		if( pars.mp.timeflag ) fprintf(pf,"time:\t%lf\t%lf\n",tmrca, ttot ) ;
+        if( (segsites > 0 ) || ( pars.mp.theta > 0.0 ) ) {
+   	       if( (pars.mp.segsitesin > 0 ) && ( pars.mp.theta > 0.0 )) 
+		       fprintf(pf,"prob: %g\n", probss ) ;
+           fprintf(pf,"segsites: %d\n",segsites);
+            if( segsites > 0 )    fprintf(pf,"positions: ");
+            for( i=0; i<segsites; i++)
+                fprintf(pf,"%6.*lf ", pars.output_precision,posit[i] );
+            fprintf(pf,"\n");
+            if( (segsites > 0) && pars.mp.ageflag ){
+                fprintf(pf,"allele ages: ");
+                for( i=0; i<segsites; i++)
+                   fprintf(pf,"%6.*lf ", pars.output_precision,agevec[i] );
+                fprintf(pf,"\n");
+                fprintf(pf,"allele freqs: ");
+                for( i=0; i<segsites; i++){
+                    for(k=afreq=0; k<pars.cp.nsam; k++) afreq += ( (list[k][i] == '1') ? 1: 0 ) ;
+                    fprintf(pf,"%d ", afreq );
+                }
+                fprintf(pf,"\n");
+            }
+	       if( segsites > 0 )
+	          for(i=0;i<pars.cp.nsam; i++) { fprintf(pf,"%s\n", list[i] ); }
+	    }
+    }
+	if( !pars.commandlineseedflag ) seedit( "end" );
+
+}
+
+
+
+	int 
+gensam( char **list, double *pprobss, double *ptmrca, double *pttot ) 
+{
+	int nsegs, h, i, k, j, seg, ns, start, end, len, segsit ;
+	struct segl *seglst, *segtre_mig(struct c_params *p, int *nsegs ) ; /* used to be: [MAXSEG];  */
+	double nsinv,  tseg, tt, ttime(struct node *, int nsam), ttimemf(struct node *, int nsam, int mfreq) ;
+	double *pk;
+	int *ss;
+	int segsitesin,nsites;
+	double theta, es ;
+	int nsam, mfreq ;
+	void prtree( struct node *ptree, int nsam);
+	void make_gametes(int nsam, int mfreq,  struct node *ptree, double tt, int newsites, int ns, char **list );
+ 	void ndes_setup( struct node *, int nsam );
+    struct node *ptree1, *ptree0 ;
+
+
+	nsites = pars.cp.nsites ;
+	nsinv = 1./nsites;
+	seglst = segtre_mig(&(pars.cp),  &nsegs ) ;
+	
+	nsam = pars.cp.nsam;
+	segsitesin = pars.mp.segsitesin ;
+    theta = pars.mp.theta ;
+	mfreq = pars.mp.mfreq ;
+
+	if( pars.mp.treeflag ) {
+	  	ns = 0 ;
+	    for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
+	      if( (pars.cp.r > 0.0 ) || (pars.cp.f > 0.0) ){
+		     end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
+		     start = seglst[seg].beg ;
+		     len = end - start + 1 ;
+		     fprintf(stdout,"[%d]", len);
+	      }
+	      prtree( seglst[seg].ptree, nsam ) ;
+	      if( (segsitesin == 0) && ( theta == 0.0 ) && ( pars.mp.timeflag == 0 ) ) 
+	  	      free(seglst[seg].ptree) ;
+	    }
+	}
+
+	if( pars.mp.timeflag ) {
+      tt = 0.0 ;
+	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) { 
+		if( mfreq > 1 ) ndes_setup( seglst[seg].ptree, nsam );
+		end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
+		start = seglst[seg].beg ;
+		if( (nsegs==1) || ( ( start <= nsites/2) && ( end >= nsites/2 ) ) )
+		  *ptmrca = (seglst[seg].ptree + 2*nsam-2) -> time ;
+		len = end - start + 1 ;
+		tseg = len/(double)nsites ;
+		if( mfreq == 1 ) tt += ttime(seglst[seg].ptree,nsam)*tseg ;
+		else tt += ttimemf(seglst[seg].ptree,nsam, mfreq)*tseg ;
+		if( (segsitesin == 0) && ( theta == 0.0 )  ) 
+	  	      free(seglst[seg].ptree) ;
+	    }
+		*pttot = tt ;
+	 }	
+	
+    if( (segsitesin == 0) && ( theta > 0.0)   ) {
+	  ns = 0 ;
+	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) { 
+		if( mfreq > 1 ) ndes_setup( seglst[seg].ptree, nsam );
+		end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
+		start = seglst[seg].beg ;
+		len = end - start + 1 ;
+		tseg = len*(theta/nsites) ;
+		if( mfreq == 1) tt = ttime(seglst[seg].ptree, nsam);
+                else tt = ttimemf(seglst[seg].ptree, nsam, mfreq );
+		segsit = poisso( tseg*tt );
+		if( (segsit + ns) >= maxsites ) {
+			maxsites = segsit + ns + SITESINC ;
+            posit = (double *)realloc(posit, maxsites*sizeof(double) ) ;
+            agevec = (double *)realloc(agevec, maxsites*sizeof(double) ) ;
+			  biggerlist(nsam, list) ;
+		}
+		make_gametes(nsam,mfreq,seglst[seg].ptree,tt, segsit, ns, list );
+		free(seglst[seg].ptree) ;
+		locate(segsit,start*nsinv, len*nsinv,posit+ns);   
+		ns += segsit;
+	  }
+    }
+   else if( segsitesin > 0 ) {
+
+        pk = (double *)malloc((unsigned)(nsegs*sizeof(double)));
+        ss = (int *)malloc((unsigned)(nsegs*sizeof(int)));
+        if( (pk==NULL) || (ss==NULL) ) perror("malloc error. gensam.2");
+
+
+	  tt = 0.0 ;
+	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) { 
+		if( mfreq > 1 ) ndes_setup( seglst[seg].ptree, nsam );
+		end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
+		start = seglst[seg].beg ;
+		len = end - start + 1 ;
+		tseg = len/(double)nsites ;
+               if( mfreq == 1 ) pk[k] = ttime(seglst[seg].ptree,nsam)*tseg ;
+               else pk[k] = ttimemf(seglst[seg].ptree,nsam, mfreq)*tseg ;
+                 tt += pk[k] ;
+	  }
+	  if( theta > 0.0 ) { 
+	    es = theta * tt ;
+	    *pprobss = exp( -es )*pow( es, (double) segsitesin) / segfac ;
+	  }
+	  if( tt > 0.0 ) {
+          for (k=0;k<nsegs;k++) pk[k] /= tt ;
+          mnmial(segsitesin,nsegs,pk,ss);
+	  }
+	  else
+            for( k=0; k<nsegs; k++) ss[k] = 0 ;
+	  ns = 0 ;
+	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) { 
+		 end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
+		 start = seglst[seg].beg ;
+		 len = end - start + 1 ;
+		 tseg = len/(double)nsites;
+		 make_gametes(nsam,mfreq,seglst[seg].ptree,tt*pk[k]/tseg, ss[k], ns, list);
+
+		 free(seglst[seg].ptree) ;
+		 locate(ss[k],start*nsinv, len*nsinv,posit+ns);   
+		 ns += ss[k] ;
+	  }
+	  free(pk);
+	  free(ss);
+
+    }
+	for(i=0;i<nsam;i++) list[i][ns] = '\0' ;
+	return( ns ) ;
+}
+
+	void 
+ndes_setup(struct node *ptree, int nsam )
+{
+	int i ;
+
+	for( i=0; i<nsam; i++) (ptree+i)->ndes = 1 ;
+	for( i = nsam; i< 2*nsam -1; i++) (ptree+i)->ndes = 0 ;
+	for( i= 0; i< 2*nsam -2 ; i++)  (ptree+((ptree+i)->abv))->ndes += (ptree+i)->ndes ;
+
+}
+
+	void
+biggerlist(int nsam,  char **list )
+{
+	int i;
+
+/*  fprintf(stderr,"maxsites: %d\n",maxsites);  */	
+	for( i=0; i<nsam; i++){
+	   list[i] = (char *)realloc( list[i],maxsites*sizeof(char) ) ;
+	   if( list[i] == NULL ) perror( "realloc error. bigger");
+	   }
+}
+	   
+
+
+/* allocates space for gametes (character strings) */
+	char **
+cmatrix(nsam,len)
+	int nsam, len;
+{
+	int i;
+	char **m;
+
+	if( ! ( m = (char **) malloc( (unsigned) nsam*sizeof( char* ) ) ) )
+	   perror("alloc error in cmatrix") ;
+	for( i=0; i<nsam; i++) {
+		if( ! ( m[i] = (char *) malloc( (unsigned) len*sizeof( char ) )))
+			perror("alloc error in cmatric. 2");
+		}
+	return( m );
+}
+
+
+
+	void
+locate(int n,double beg, double len,double *ptr)
+{
+	int i;
+
+	ordran(n,ptr);
+	for(i=0; i<n; i++)
+		ptr[i] = beg + ptr[i]*len ;
+
+}
+
+int NSEEDS = 3 ;
+
+  void
+getpars(int argc, char *argv[], int *phowmany )
+{
+	int arg, i, j, sum , pop , argstart, npop , npop2, pop2 ;
+	double migr, mij, psize, palpha ;
+	void addtoelist( struct devent *pt, struct devent *elist ); 
+	void argcheck( int arg, int argc, char ** ) ;
+	int commandlineseed( char ** ) ;
+	void free_eventlist( struct devent *pt, int npop );
+	struct devent *ptemp , *pt ;
+	FILE *pf ;
+	char ch3 ;
+	
+
+  if( count == 0 ) {
+	if( argc < 4 ){ fprintf(stderr,"Too few command line arguments\n"); usage();}
+/* adna */
+	pars.cp.nsamin = atoi( argv[1] );
+      pars.cp.nsam = pars.cp.nsamin ;
+	if( pars.cp.nsam <= 0 ) { fprintf(stderr,"First argument error. nsam <= 0. \n"); usage();}
+	*phowmany = atoi( argv[2] );
+	if( *phowmany  <= 0 ) { fprintf(stderr,"Second argument error. howmany <= 0. \n"); usage();}
+	pars.commandlineseedflag = 0 ;
+	  pars.output_precision = 4 ;
+	pars.cp.r = pars.mp.theta =  pars.cp.f = 0.0 ;
+	pars.cp.track_len = 0. ;
+	pars.cp.npop = npop = 1 ;
+	pars.cp.mig_mat = (double **)malloc( (unsigned) sizeof( double *) );
+	pars.cp.mig_mat[0] = (double *)malloc( (unsigned)sizeof(double ));
+	pars.cp.mig_mat[0][0] =  0.0 ;
+	pars.mp.segsitesin = 0 ;
+	pars.mp.treeflag = 0 ;
+ 	pars.mp.timeflag = 0 ;
+    pars.mp.ageflag = 0 ;
+       pars.mp.mfreq = 1 ;
+	pars.cp.config = (int *) malloc( (unsigned)(( pars.cp.npop +1 ) *sizeof( int)) );
+/* adna */
+    (pars.cp.config)[0] = pars.cp.nsamin ;
+	pars.cp.size= (double *) malloc( (unsigned)( pars.cp.npop *sizeof( double )) );
+	(pars.cp.size)[0] = 1.0  ;
+	pars.cp.alphag = (double *) malloc( (unsigned)(( pars.cp.npop ) *sizeof( double )) );
+	(pars.cp.alphag)[0] = 0.0  ;
+	pars.cp.nsites = 2 ;
+  }
+  else{
+	npop = pars.cp.npop ;
+	free_eventlist( pars.cp.deventlist, npop );
+  }
+  	pars.cp.deventlist = NULL ;
+
+	arg = 3 ;
+
+	while( arg < argc ){
+		if( argv[arg][0] != '-' ) { fprintf(stderr," argument should be -%s ?\n", argv[arg]); usage();}
+		switch ( argv[arg][1] ){
+			case 'f' :
+				if( ntbs > 0 ) { fprintf(stderr," can't use tbs args and -f option.\n"); exit(1); }
+				arg++;
+				argcheck( arg, argc, argv);
+				pf = fopen( argv[arg], "r" ) ;
+				if( pf == NULL ) {fprintf(stderr," no parameter file %s\n", argv[arg] ); exit(0);}
+				arg++;
+				argc++ ;
+				argv = (char **)malloc(  (unsigned)(argc+1)*sizeof( char *) ) ;
+				argv[arg] = (char *)malloc( (unsigned)(20*sizeof( char )) ) ;
+				argstart = arg ;
+				while( fscanf(pf," %s", argv[arg]) != EOF ) {
+					arg++;
+					argc++;
+					argv = (char **)realloc( argv, (unsigned)argc*sizeof( char*) ) ;
+				        argv[arg] = (char *)malloc( (unsigned)(20*sizeof( char )) ) ;
+					}
+				fclose(pf);
+				argc--;
+				arg = argstart ;
+				break;
+			case 'r' : 
+				arg++;
+				argcheck( arg, argc, argv);
+				pars.cp.r = atof(  argv[arg++] );
+				argcheck( arg, argc, argv);
+				pars.cp.nsites = atoi( argv[arg++]);
+				if( pars.cp.nsites <2 ){
+					fprintf(stderr,"with -r option must specify both rec_rate and nsites>1\n");
+					usage();
+					}
+				break;	
+			case 'p' :
+				arg++;
+				argcheck(arg,argc,argv);
+				pars.output_precision = atoi( argv[arg++] ) ;
+				break;
+			case 'c' : 
+				arg++;
+				argcheck( arg, argc, argv);
+				pars.cp.f = atof(  argv[arg++] );
+				argcheck( arg, argc, argv);
+				pars.cp.track_len = atof( argv[arg++]);
+				if( pars.cp.track_len <1. ){
+					fprintf(stderr,"with -c option must specify both f and track_len>0\n");
+					usage();
+					}
+				break;		
+			case 't' : 
+				arg++;
+				argcheck( arg, argc, argv);
+				pars.mp.theta = atof(  argv[arg++] );
+				break;
+			case 's' : 
+				arg++;
+				argcheck( arg, argc, argv);
+				if( argv[arg-1][2] == 'e' ){  /* command line seeds */
+					pars.commandlineseedflag = 1 ;
+					if( count == 0 ) nseeds = commandlineseed(argv+arg );
+					arg += nseeds ;
+				}
+				else {
+				    pars.mp.segsitesin = atoi(  argv[arg++] );
+				}
+				break;
+			case 'F' : 
+				arg++;
+				argcheck( arg, argc, argv);
+				pars.mp.mfreq = atoi(  argv[arg++] );
+                                if( (pars.mp.mfreq < 2 ) || (pars.mp.mfreq > pars.cp.nsam/2 ) ){
+                                    fprintf(stderr," mfreq must be >= 2 and <= nsam/2.\n");
+                                    usage();
+                                    }
+				break;
+			case 'T' : 
+				pars.mp.treeflag = 1 ;
+				arg++;
+				break;
+			case 'L' : 
+				pars.mp.timeflag = 1 ;
+				arg++;
+				break;
+            case 'a' :
+                pars.mp.ageflag = 1 ;
+                arg++;
+                break;
+			case 'I' : 
+			    arg++;
+			    if( count == 0 ) {
+				argcheck( arg, argc, argv);
+			       	pars.cp.npop = atoi( argv[arg]);
+			        pars.cp.config = (int *) realloc( pars.cp.config, (unsigned)( pars.cp.npop*sizeof( int)));
+				npop = pars.cp.npop ;
+				}
+			    arg++;
+			    for( i=0; i< pars.cp.npop; i++) {
+				argcheck( arg, argc, argv);
+				pars.cp.config[i] = atoi( argv[arg++]);
+				}
+			    if( count == 0 ){
+				pars.cp.mig_mat = 
+                                        (double **)realloc(pars.cp.mig_mat, (unsigned)(pars.cp.npop*sizeof(double *) )) ;
+				pars.cp.mig_mat[0] = 
+                                         (double *)realloc(pars.cp.mig_mat[0], (unsigned)( pars.cp.npop*sizeof(double)));
+				for(i=1; i<pars.cp.npop; i++) pars.cp.mig_mat[i] = 
+                                         (double *)malloc( (unsigned)( pars.cp.npop*sizeof(double)));
+				pars.cp.size = (double *)realloc( pars.cp.size, (unsigned)( pars.cp.npop*sizeof( double )));
+				pars.cp.alphag = 
+                                          (double *) realloc( pars.cp.alphag, (unsigned)( pars.cp.npop*sizeof( double )));
+			        for( i=1; i< pars.cp.npop ; i++) {
+				   (pars.cp.size)[i] = (pars.cp.size)[0]  ;
+				   (pars.cp.alphag)[i] = (pars.cp.alphag)[0] ;
+				   }
+			        }
+			     if( (arg <argc) && ( argv[arg][0] != '-' ) ) {
+				argcheck( arg, argc, argv);
+				migr = atof(  argv[arg++] );
+				}
+			     else migr = 0.0 ;
+			     for( i=0; i<pars.cp.npop; i++) 
+				    for( j=0; j<pars.cp.npop; j++) pars.cp.mig_mat[i][j] = migr/(pars.cp.npop-1) ;
+			     for( i=0; i< pars.cp.npop; i++) pars.cp.mig_mat[i][i] = migr ;
+			     break;
+			case 'm' :
+			     if( npop < 2 ) { fprintf(stderr,"Must use -I option first.\n"); usage();}
+			     if( argv[arg][2] == 'a' ) {
+				    arg++;
+				    for( pop = 0; pop <npop; pop++)
+				      for( pop2 = 0; pop2 <npop; pop2++){
+					     argcheck( arg, argc, argv);
+					     pars.cp.mig_mat[pop][pop2]= atof( argv[arg++] ) ;
+					  }
+				    for( pop = 0; pop < npop; pop++) {
+					  pars.cp.mig_mat[pop][pop] = 0.0 ;
+					  for( pop2 = 0; pop2 < npop; pop2++){
+					    if( pop2 != pop ) pars.cp.mig_mat[pop][pop] += pars.cp.mig_mat[pop][pop2] ;
+					  }
+				    }	
+				}
+			    else {
+		             arg++;
+			         argcheck( arg, argc, argv);
+		             i = atoi( argv[arg++] ) -1;
+			         argcheck( arg, argc, argv);
+		             j = atoi( argv[arg++] ) -1;
+			         argcheck( arg, argc, argv);
+		             mij = atof( argv[arg++] );
+		             pars.cp.mig_mat[i][i] += mij -  pars.cp.mig_mat[i][j]  ;
+		             pars.cp.mig_mat[i][j] = mij;
+			    }
+				break;
+			case 'n' :
+			     if( npop < 2 ) { fprintf(stderr,"Must use -I option first.\n"); usage();}
+			    arg++;
+			    argcheck( arg, argc, argv);
+			    pop = atoi( argv[arg++] ) -1;
+			    argcheck( arg, argc, argv);
+			    psize = atof( argv[arg++] );
+			    pars.cp.size[pop] = psize ;
+			   break;
+			case 'g' :
+			     if( npop < 2 ) { fprintf(stderr,"Must use -I option first.\n"); usage();}
+			    arg++;
+			    argcheck( arg, argc, argv);
+			    pop = atoi( argv[arg++] ) -1;
+			    if( arg >= argc ) { fprintf(stderr,"Not enough arg's after -G.\n"); usage(); }
+			    palpha = atof( argv[arg++] );
+			    pars.cp.alphag[pop] = palpha ;
+			   break;
+			case 'G' :
+			    arg++;
+			    if( arg >= argc ) { fprintf(stderr,"Not enough arg's after -G.\n"); usage(); }
+			    palpha = atof( argv[arg++] );
+			    for( i=0; i<pars.cp.npop; i++) 
+			       pars.cp.alphag[i] = palpha ;
+			   break;
+			case 'e' :
+			    pt = (struct devent *)malloc( sizeof( struct devent) ) ;
+			    pt->detype = argv[arg][2] ;
+			    ch3 = argv[arg][3] ;
+			    arg++;
+			    argcheck( arg, argc, argv);
+			    pt->time = atof( argv[arg++] ) ;
+			    pt->nextde = NULL ;
+			    if( pars.cp.deventlist == NULL ) 
+				    pars.cp.deventlist = pt ;
+			    else if ( pt->time < pars.cp.deventlist->time ) { 
+				    ptemp = pars.cp.deventlist ;
+				    pars.cp.deventlist = pt ;
+				    pt->nextde = ptemp ;	
+				}	
+			    else
+				   addtoelist( pt, pars.cp.deventlist ) ;
+			    switch( pt->detype ) {
+				case 'N' :
+			          argcheck( arg, argc, argv);
+				      pt->paramv = atof( argv[arg++] ) ;
+				      break;
+				case 'G' :
+				  if( arg >= argc ) { fprintf(stderr,"Not enough arg's after -eG.\n"); usage(); }
+				  pt->paramv = atof( argv[arg++] ) ;
+				  break;
+				case 'M' :
+				    argcheck( arg, argc, argv);
+				    pt->paramv = atof( argv[arg++] ) ;
+				    break;
+				case 'n' :
+			          argcheck( arg, argc, argv);
+				  pt->popi = atoi( argv[arg++] ) -1 ;
+			          argcheck( arg, argc, argv);
+				  pt->paramv = atof( argv[arg++] ) ;
+				  break;
+				case 'g' :
+			          argcheck( arg, argc, argv);
+				  pt->popi = atoi( argv[arg++] ) -1 ;
+				  if( arg >= argc ) { fprintf(stderr,"Not enough arg's after -eg.\n"); usage(); }
+				  pt->paramv = atof( argv[arg++] ) ;
+				  break;
+				case 's' :
+			          argcheck( arg, argc, argv);
+				  pt->popi = atoi( argv[arg++] ) -1 ;
+			          argcheck( arg, argc, argv);
+				  pt->paramv = atof( argv[arg++] ) ;
+				  break;
+				case 'm' :
+				  if( ch3 == 'a' ) {
+				     pt->detype = 'a' ;
+				     argcheck( arg, argc, argv);
+				     npop2 = atoi( argv[arg++] ) ;
+				     pt->mat = (double **)malloc( (unsigned)npop2*sizeof( double *) ) ;
+				     for( pop =0; pop <npop2; pop++){
+					   (pt->mat)[pop] = (double *)malloc( (unsigned)npop2*sizeof( double) );
+					   for( i=0; i<npop2; i++){
+					     if( i == pop ) arg++;
+					     else {
+				               argcheck( arg, argc, argv); 
+					       (pt->mat)[pop][i] = atof( argv[arg++] ) ;
+					     }
+					   }
+				     }
+				     for( pop = 0; pop < npop2; pop++) {
+					    (pt->mat)[pop][pop] = 0.0 ;
+					    for( pop2 = 0; pop2 < npop2; pop2++){
+					       if( pop2 != pop ) (pt->mat)[pop][pop] += (pt->mat)[pop][pop2] ;
+					    }
+				     }	
+				  }
+				  else {
+			            argcheck( arg, argc, argv);
+				        pt->popi = atoi( argv[arg++] ) -1 ;
+			            argcheck( arg, argc, argv);
+				        pt->popj = atoi( argv[arg++] ) -1 ;
+			            argcheck( arg, argc, argv);
+				        pt->paramv = atof( argv[arg++] ) ;
+				  }
+				  break;
+				case 'j' :
+			          argcheck( arg, argc, argv);
+				  pt->popi = atoi( argv[arg++] ) -1 ;
+			          argcheck( arg, argc, argv);
+				  pt->popj = atoi( argv[arg++] ) -1 ;
+				  break;
+        /* adna */
+                case 'A' :
+                        argcheck( arg, argc, argv);
+                        pt->popi = atoi( argv[arg++] ) -1 ;
+                        argcheck( arg, argc, argv);
+                        pt->num = atoi( argv[arg++] ) ;
+                        pars.cp.nsam += pt->num ;
+                        break;
+				default: fprintf(stderr,"e event\n");  usage();
+			    }
+			 break;
+			default: fprintf(stderr," option default\n");  usage() ;
+			}
+		}
+		if( (pars.mp.theta == 0.0) && ( pars.mp.segsitesin == 0 ) && ( pars.mp.treeflag == 0 ) && (pars.mp.timeflag == 0) ) {
+			fprintf(stderr," either -s or -t or -T option must be used. \n");
+			usage();
+			exit(1);
+			}
+		sum = 0 ;
+		for( i=0; i< pars.cp.npop; i++) sum += (pars.cp.config)[i] ;
+		if( sum != pars.cp.nsamin ) {   /* adna */
+			fprintf(stderr," sum sample sizes != nsam\n");
+			usage();
+			exit(1);
+			}
+}
+
+
+	void
+argcheck( int arg, int argc, char *argv[] )
+{
+	if( (arg >= argc ) || ( argv[arg][0] == '-') ) {
+	   fprintf(stderr,"not enough arguments after %s\n", argv[arg-1] ) ;
+	   fprintf(stderr,"For usage type: ms<return>\n");
+	   exit(0);
+	  }
+}
+	
+	void
+usage()
+{
+fprintf(stderr,"usage: ms nsam howmany \n");
+fprintf(stderr,"  Options: \n"); 
+fprintf(stderr,"\t -t theta   (this option and/or the next must be used. Theta = 4*N0*u )\n");
+fprintf(stderr,"\t -s segsites   ( fixed number of segregating sites)\n");
+fprintf(stderr,"\t -T          (Output gene tree.)\n");
+fprintf(stderr,"\t -F minfreq     Output only sites with freq of minor allele >= minfreq.\n");
+fprintf(stderr,"\t -r rho nsites     (rho here is 4Nc)\n");
+fprintf(stderr,"\t\t -c f track_len   (f = ratio of conversion rate to rec rate. tracklen is mean length.) \n");
+fprintf(stderr,"\t\t\t if rho = 0.,  f = 4*N0*g, with g the gene conversion rate.\n"); 
+fprintf(stderr,"\t -G alpha  ( N(t) = N0*exp(-alpha*t) .  alpha = -log(Np/Nr)/t\n");      
+fprintf(stderr,"\t -I npop n1 n2 ... [mig_rate] (all elements of mig matrix set to mig_rate/(npop-1) \n");    
+fprintf(stderr,"\t\t -m i j m_ij    (i,j-th element of mig matrix set to m_ij.)\n"); 
+fprintf(stderr,"\t\t -ma m_11 m_12 m_13 m_21 m_22 m_23 ...(Assign values to elements of migration matrix.)\n"); 
+fprintf(stderr,"\t\t -n i size_i   (popi has size set to size_i*N0 \n");
+fprintf(stderr,"\t\t -g i alpha_i  (If used must appear after -M option.)\n"); 
+fprintf(stderr,"\t   The following options modify parameters at the time 't' specified as the first argument:\n");
+fprintf(stderr,"\t -eG t alpha  (Modify growth rate of all pop's.)\n");     
+fprintf(stderr,"\t -eg t i alpha_i  (Modify growth rate of pop i.) \n");    
+fprintf(stderr,"\t -eM t mig_rate   (Modify the mig matrix so all elements are mig_rate/(npop-1)\n"); 
+fprintf(stderr,"\t -em t i j m_ij    (i,j-th element of mig matrix set to m_ij at time t )\n"); 
+fprintf(stderr,"\t -ema t npop  m_11 m_12 m_13 m_21 m_22 m_23 ...(Assign values to elements of migration matrix.)\n");  
+fprintf(stderr,"\t -eN t size  (Modify pop sizes. New sizes = size*N0 ) \n");    
+fprintf(stderr,"\t -en t i size_i  (Modify pop size of pop i.  New size of popi = size_i*N0 .)\n");
+fprintf(stderr,"\t -es t i proportion  (Split: pop i -> pop-i + pop-npop, npop increases by 1.\n");    
+fprintf(stderr,"\t\t proportion is probability that each lineage stays in pop-i. (p, 1-p are admixt. proport.\n");
+fprintf(stderr,"\t\t Size of pop npop is set to N0 and alpha = 0.0 , size and alpha of pop i are unchanged.\n");
+fprintf(stderr,"\t -ej t i j   ( Join lineages in pop i and pop j into pop j\n");
+fprintf(stderr,"\t\t  size, alpha and M are unchanged.\n");
+fprintf( stderr,"\t -eA t popi num ( num Ancient samples from popi at time t\n") ;
+fprintf(stderr,"\t  -f filename     ( Read command line arguments from file filename.)\n"); 
+fprintf(stderr,"\t  -p n ( Specifies the precision of the position output.  n is the number of digits after the decimal.)\n");
+fprintf(stderr,"\t  -a (Print out allele ages.)\n");
+fprintf(stderr," See msdoc.pdf for explanation of these parameters.\n");
+
+exit(1);
+}
+	void
+addtoelist( struct devent *pt, struct devent *elist ) 
+{
+	struct devent *plast, *pevent, *ptemp  ;
+
+	pevent = elist ;
+	while(  (pevent != NULL ) && ( pevent->time <= pt->time ) )  {
+		plast = pevent ;
+		pevent = pevent->nextde ;
+		}
+	ptemp = plast->nextde ;
+	plast->nextde = pt ;
+	pt->nextde = ptemp ;
+}
+
+	void 
+free_eventlist( struct devent *pt, int npop )
+{
+   struct devent *next ;
+   int pop ;
+   
+   while( pt != NULL){
+	  next = pt->nextde ;
+	  if( pt->detype == 'a' ) {
+	     for( pop = 0; pop < npop; pop++) free( (pt->mat)[pop] );
+		 free( pt->mat );
+	  }
+	  free(pt);
+	  pt = next ;
+   }
+}
+
+	
+/************ make_gametes.c  *******************************************
+*
+*
+*****************************************************************************/
+
+#define STATE1 '1'
+#define STATE2 '0'
+
+	void
+make_gametes(int nsam, int mfreq, struct node *ptree, double tt, int newsites, int ns, char **list )
+{
+	int  tip, j,  node ;
+        int pickb(int nsam, struct node *ptree, double tt), 
+            pickbmf(int nsam, int mfreq, struct node *ptree, double tt) ;
+
+	for(  j=ns; j< ns+newsites ;  j++ ) {
+		if( mfreq == 1 ) node = pickb(  nsam, ptree, tt);
+		else node = pickbmf(  nsam, mfreq, ptree, tt);
+        agevec[j] = alleleage ;
+		for( tip=0; tip < nsam ; tip++) {
+		   if( tdesn(ptree, tip, node) ) list[tip][j] = STATE1 ;
+		   else list[tip][j] = STATE2 ;
+        }
+    }
+}
+
+
+/***  ttime.c : Returns the total time in the tree, *ptree, with nsam tips. **/
+
+	double
+ttime( ptree, nsam)
+	struct node *ptree;
+	int nsam;
+{
+	double t;
+	int i;
+
+	t = (ptree + 2*nsam-2) -> time ;
+	for( i=nsam; i< 2*nsam-1 ; i++)
+		t += (ptree + i)-> time ;
+    /* adna */
+        for( i=0; i<nsam; i++)
+            t -= (ptree+i)->time ;
+	return(t);
+}
+
+
+	double
+ttimemf( ptree, nsam, mfreq)
+	struct node *ptree;
+	int nsam, mfreq;
+{
+	double t;
+	int i;
+
+	t = 0. ;
+	for( i=0;  i< 2*nsam-2  ; i++)
+	  if( ( (ptree+i)->ndes >= mfreq )  && ( (ptree+i)->ndes <= nsam-mfreq) )
+		t += (ptree + (ptree+i)->abv )->time - (ptree+i)->time ;
+	return(t);
+}
+
+
+	void
+prtree( ptree, nsam)
+	struct node *ptree;
+	int nsam;
+{
+	double t;
+	int i, *descl, *descr ;
+	void parens( struct node *ptree, int *descl, int *descr, int noden );
+
+	descl = (int *)malloc( (unsigned)(2*nsam-1)*sizeof( int) );
+	descr = (int *)malloc( (unsigned)(2*nsam-1)*sizeof( int) );
+	for( i=0; i<2*nsam-1; i++) descl[i] = descr[i] = -1 ;
+	for( i = 0; i< 2*nsam-2; i++){
+	  if( descl[ (ptree+i)->abv ] == -1 ) descl[(ptree+i)->abv] = i ;
+	  else descr[ (ptree+i)->abv] = i ;
+	 }
+	parens( ptree, descl, descr, 2*nsam-2);
+	free( descl ) ;
+	free( descr ) ;
+}
+
+	void
+parens( struct node *ptree, int *descl, int *descr,  int noden)
+{
+	double time ;
+
+   if( descl[noden] == -1 ) {
+	printf("%d:%5.3lf", noden+1, (ptree+ ((ptree+noden)->abv))->time  - (ptree+noden )->time ); /* adna */
+	}
+   else{
+	printf("(");
+	parens( ptree, descl,descr, descl[noden] ) ;
+	printf(",");
+	parens(ptree, descl, descr, descr[noden] ) ;
+	if( (ptree+noden)->abv == 0 ) printf(");\n"); 
+	else {
+	  time = (ptree + (ptree+noden)->abv )->time - (ptree+noden)->time ;
+	  printf("):%5.3lf", time );
+	  }
+        }
+}
+
+/***  pickb : returns a random branch from the tree. The probability of picking
+              a particular branch is proportional to its duration. tt is total
+	      time in tree.   ****/
+
+	int
+pickb(nsam, ptree, tt)
+	int nsam;
+	struct node *ptree;
+	double tt;
+{
+	double x, y, ran1();
+	int i;
+
+	x = ran1()*tt;
+	for( i=0, y=0; i < 2*nsam-2 ; i++) {
+		y += (ptree + (ptree+i)->abv )->time - (ptree+i)->time ;
+        if( y >= x ) {
+            alleleage = (ptree+i)->time + ran1()* ( (ptree + (ptree+i)->abv )->time - (ptree+i)->time ) ;
+            return( i ) ;
+        }
+        
+    }
+    i = 2*nsam - 3 ;
+    alleleage = (ptree+i)->time + ran1()* ( (ptree + (ptree+i)->abv )->time - (ptree+i)->time ) ;
+	return( 2*nsam - 3  );  /* changed 4 Feb 2010 */
+}
+
+	int
+pickbmf(nsam, mfreq, ptree, tt )
+	int nsam, mfreq;
+	struct node *ptree;
+	double tt;
+{
+	double x, y, ran1();
+	int i, lastbranch = 0 ;
+
+	x = ran1()*tt;
+	for( i=0, y=0; i < 2*nsam-2 ; i++) {
+	  if( ( (ptree+i)->ndes >= mfreq )  && ( (ptree+i)->ndes <= nsam-mfreq) ){
+		y += (ptree + (ptree+i)->abv )->time - (ptree+i)->time ;
+		lastbranch = i ;    /* changed 4 Feb 2010 */
+	  }
+     if( y >= x ) {
+            alleleage = (ptree+i)->time + ran1()* ( (ptree + (ptree+i)->abv )->time - (ptree+i)->time ) ;
+            return( i ) ;
+     }
+	}
+    i = lastbranch;
+    alleleage = (ptree+i)->time + ran1()* ( (ptree + (ptree+i)->abv )->time - (ptree+i)->time ) ;
+	return( lastbranch );   /*  changed 4 Feb 2010 */
+}
+
+/****  tdesn : returns 1 if tip is a descendant of node in *ptree, otherwise 0. **/
+
+	int
+tdesn(struct node *ptree, int tip, int node )
+{
+	int k;
+
+	for( k= tip ; k < node ; k = (ptree+k)->abv ) ;
+	if( k==node ) return(1);
+	else return(0);
+}
+
+
+/* pick2()  */
+
+	int
+pick2(int n, int *i, int *j)
+{
+	double ran1();
+
+	*i = n * ran1() ;
+	while( ( *j = n * ran1() ) == *i )
+		;
+	return(0) ;
+}
+
+/**** ordran.c  ***/
+
+	void
+ordran(int n,double pbuf[])
+{
+	ranvec(n,pbuf);
+	order(n,pbuf);
+	return;
+}
+
+
+	void
+mnmial(int n, int nclass, double p[], int rv[])
+{
+	double ran1();
+	double x, s;
+	int i, j;
+
+	for(i=0; i<nclass; i++) rv[i]=0;
+	for(i=0; i<n ; i++) {
+	   x = ran1();
+	   j=0;
+	   s = p[0];
+	   while( (x > s) && ( j<(nclass-1) ) )  s += p[++j];
+	   rv[j]++;
+	   }
+	return;
+}
+
+        void
+order(int n,double pbuf[])
+{
+        int gap, i, j;
+        double temp;
+
+        for( gap= n/2; gap>0; gap /= 2)
+           for( i=gap; i<n; i++)
+                for( j=i-gap; j>=0 && pbuf[j]>pbuf[j+gap]; j -=gap) {
+                   temp = pbuf[j];
+                   pbuf[j] = pbuf[j+gap];
+                   pbuf[j+gap] = temp;
+                   }
+    return;
+}
+
+
+	void
+ranvec(int n,double pbuf[])
+{
+	int i;
+	double ran1();
+
+	for(i=0; i<n; i++)
+		pbuf[i] = ran1();
+
+	return;
+}
+
+
+
+	int
+poisso(double u)
+{
+	double  cump, ru, ran1(), p, gasdev(double, double) ;
+	int i=1;
+
+	if( u > 30. ){
+	    i =  (int)(0.5 + gasdev(u,u)) ;
+	    if( i < 0 ) return( 0 ) ;
+	    else return( i ) ;
+	  }
+	 
+	ru = ran1();
+	p = exp(-u);
+	if( ru < p) return(0);
+	cump = p;
+	
+	while( ru > ( cump += (p *= u/i ) ) )
+		i++;
+	return(i);
+}
+
+
+/* a slight modification of crecipes version */
+
+double gasdev(m,v)
+	double m, v;
+{
+	static int iset=0;
+	static float gset;
+	float fac,r,v1,v2;
+	double ran1();
+
+	if  (iset == 0) {
+		do {
+			v1=2.0*ran1()-1.0;
+			v2=2.0*ran1()-1.0;
+			r=v1*v1+v2*v2;
+		} while (r >= 1.0);
+		fac=sqrt(-2.0*log(r)/r);
+		gset= v1*fac;
+		iset=1;
+		return( m + sqrt(v)*v2*fac);
+	} else {
+		iset=0;
+		return( m + sqrt(v)*gset ) ;
+	}
+}
+

--- a/evaluation/sims/msdir/ms.h
+++ b/evaluation/sims/msdir/ms.h
@@ -1,0 +1,60 @@
+struct devent {
+	double time;
+	int popi;
+	int popj;
+	double paramv;
+    int num ;  /* adna */
+	double **mat ;
+	char detype ;
+	struct devent *nextde;
+	} ;
+struct c_params {
+	int npop;
+	int nsam; /* total sample size including ancient samples */
+    int nsamin;  /*  sample size at present time,  does not include ancient samples */
+	int *config;
+	double **mig_mat;
+	double r;
+	int nsites;
+	double f;
+	double track_len;
+	double *size;
+	double *alphag;
+	struct devent *deventlist ;
+	} ;
+struct m_params {
+	 double theta;
+	int segsitesin;
+	int treeflag;
+	int timeflag;
+	int mfreq;
+    int ageflag ;
+	 } ;
+struct params { 
+	struct c_params cp;
+	struct m_params mp;
+	int commandlineseedflag ;
+	int output_precision;
+	};
+
+struct node{
+	int abv;
+	int ndes;
+	float time;
+};
+
+
+/*KRT -- prototypes added*/
+void ordran(int n, double pbuf[]);
+void ranvec(int n, double pbuf[]);
+void order(int n, double pbuf[]);
+
+void biggerlist(int nsam,  char **list );
+int poisso(double u);
+void locate(int n,double beg, double len,double *ptr);
+void mnmial(int n, int nclass, double p[], int rv[]);
+void usage();
+int tdesn(struct node *ptree, int tip, int node );
+int pick2(int n, int *i, int *j);
+int xover(int nsam,int ic, int is);
+int links(int c);

--- a/evaluation/sims/msdir/rand1.c
+++ b/evaluation/sims/msdir/rand1.c
@@ -1,0 +1,57 @@
+/*  Link in this file for random number generation using drand48() */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+         double
+ran1()
+{
+        double drand48();
+        return( drand48() );
+}               
+
+
+	void seedit( char *flag )
+{
+	FILE *fopen(), *pfseed;
+	unsigned short seedv[3], seedv2[3],  *seed48(), *pseed ;
+	int i;
+
+	if( flag[0] == 's' ) {
+	   pfseed = fopen("seedms","r");
+	   if( pfseed == NULL ) {
+           seedv[0] = 3579 ; seedv[1] = 27011; seedv[2] = 59243; 
+	   }
+	   else {
+	       seedv2[0] = 3579; seedv2[1] = 27011; seedv2[2] = 59243; 
+           for(i=0;i<3;i++){ 
+		       if(  fscanf(pfseed," %hd",seedv+i) < 1 )
+		            seedv[i] = seedv2[i] ;
+		   }
+	       fclose( pfseed);
+	   }
+	   seed48( seedv );   
+
+       printf("\n%d %d %d\n", seedv[0], seedv[1], seedv[2] );    
+	}
+	else {
+	     pfseed = fopen("seedms","w");
+         pseed = seed48(seedv);
+         fprintf(pfseed,"%d %d %d\n",pseed[0], pseed[1],pseed[2]);     
+	}
+}
+
+	int
+commandlineseed( char **seeds)
+{
+	unsigned short seedv[3], *seed48();
+
+	seedv[0] = atoi( seeds[0] );
+	seedv[1] = atoi( seeds[1] );
+	seedv[2] = atoi( seeds[2] );
+	printf("\n%d %d %d\n", seedv[0], seedv[1], seedv[2] );    
+
+	seed48(seedv);
+	return(3);
+}
+

--- a/evaluation/sims/msdir/streec.c
+++ b/evaluation/sims/msdir/streec.c
@@ -1,0 +1,757 @@
+/**********  segtre_mig.c **********************************
+*
+*	This subroutine uses a Monte Carlo algorithm described in
+*	Hudson,R. 1983. Theor.Pop.Biol. 23: 183-201, to produce
+*	a history of a random sample of gametes under a neutral
+*	Wright-Fisher model with recombination and geographic structure. 
+*	Input parameters
+*	are the sample size (nsam), the number of sites between
+*	which recombination can occur (nsites), and the recombination
+*	rate between the ends of the gametes (r). The function returns
+*	nsegs, the number of segments the gametes were broken into
+*	in tracing back the history of the gametes.  The histories of
+*	these segments are passed back to the calling function in the
+*	array of structures seglst[]. An element of this array,  seglst[i],
+* 	consists of three parts: (1) beg, the starting point of
+*	of segment i, (2) ptree, which points to the first node of the
+*	tree representing the history of the segment, (3) next, which
+*	is the index number of the next segment.
+*	     A tree is a contiguous set of 2*nsam nodes. The first nsam
+*	nodes are the tips of the tree, the sampled gametes.  The other
+*	nodes are the nodes ancestral to the sampled gametes. Each node
+*	consists of an "abv" which is the number of the node ancestral to
+*	that node, an "ndes", which is not used or assigned to in this routine,
+*	and a "time", which is the time (in units of 4N generations) of the
+*	node. For the tips, time equals zero.
+*	Returns a pointer to an array of segments, seglst.
+
+**************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ms.h"
+#define NL putchar('\n')
+#define size_t unsigned
+
+#define MIN(x, y) ( (x)<(y) ? (x) : (y) )
+
+#define ERROR(message) fprintf(stderr,message),NL,exit(1)
+
+#define SEGINC 80 
+
+extern int flag;
+
+int nchrom, begs, nsegs;
+long nlinks ;
+static int *nnodes = NULL ;  
+double t, cleft , pc, lnpc ;
+
+static unsigned seglimit = SEGINC ;
+static unsigned maxchr ;
+
+struct seg{
+	int beg;
+	int end;
+	int desc;
+	};
+
+struct chromo{
+	int nseg;
+	int pop;
+	struct seg  *pseg;
+	} ;
+
+static struct chromo *chrom = NULL ;
+
+struct node *ptree1, *ptree2, *ptree0 ;
+
+struct segl {
+	int beg;
+	struct node *ptree;
+	int next;
+	}  ;
+static struct segl *seglst = NULL ;
+
+	struct segl *
+segtre_mig(struct c_params *cp, int *pnsegs ) 
+{
+	int i, j, k, seg, dec, pop, pop2, c1, c2, ind, rchrom, intn, nsamin , numanc, num ;
+	int migrant, source_pop, *config, flagint ;
+	double  ran1(), sum, x, tcoal, ttemp, rft, clefta,  tmin, p  ;
+	double prec, cin,  prect, nnm1, nnm0, mig, ran, coal_prob, prob, rdum , arg ;
+	char c, event ;
+	int re(), cinr(), cleftr(), eflag, cpop, ic  ;
+	int nsam, npop, nsites, nintn, *inconfig ;
+	double r,  f, rf,  track_len, *nrec, *npast, *tpast, **migm ;
+	double *size, *alphag, *tlast ;
+	struct devent *nextevent ;
+    int ca(int nsam, int nsites, int c1, int c2);
+	void pick2_chrom(int pop,int config[], int *pc1, int *pc2);
+
+	nsam = cp->nsam;
+    nsamin = cp->nsamin ;  /* adna */
+    numanc = nsam - nsamin ; /* adna */
+	npop = cp->npop;
+	nsites = cp->nsites;
+	inconfig = cp->config;
+	r = cp->r ;
+	f = cp->f ;
+	track_len = cp->track_len ;
+	migm = (double **)malloc( (unsigned)npop*sizeof(double *) ) ;
+	for( i=0; i<npop; i++) {
+	  migm[i] = (double *)malloc( (unsigned)npop*sizeof( double) ) ;
+	  for( j=0; j<npop; j++) migm[i][j] = (cp->mig_mat)[i][j] ;
+	  }
+	nextevent = cp->deventlist ;
+	
+/* Initialization */
+	if( chrom == NULL ) {
+	   maxchr = nsam + 20 ;
+	   chrom = (struct chromo *)malloc( (unsigned)( maxchr*sizeof( struct chromo) )) ;
+	  if( chrom == NULL ) perror( "malloc error. segtre");
+	  }
+	if( nnodes == NULL ){
+		nnodes = (int*) malloc((unsigned)(seglimit*sizeof(int)))  ;
+		if( nnodes == NULL ) perror("malloc error. segtre_mig");
+		}
+	if( seglst == NULL ) {
+		seglst = (struct segl *)malloc((unsigned)(seglimit*sizeof(struct segl)) ) ;
+		if( seglst == NULL ) perror("malloc error. segtre_mig.c 2");
+		}
+
+	config = (int *)malloc( (unsigned) ((npop+1)*sizeof(int) )) ;
+	if( config == NULL ) perror("malloc error. segtre.");
+	size = (double *)malloc( (unsigned) ((npop)*sizeof(double) )) ;
+	if( size == NULL ) perror("malloc error. segtre.");
+	alphag = (double *)malloc( (unsigned) ((npop)*sizeof(double) )) ;
+	if( alphag == NULL ) perror("malloc error. segtre.");
+	tlast = (double *)malloc( (unsigned) ((npop)*sizeof(double) )) ;
+	if( alphag == NULL ) perror("malloc error. segtre.");
+	for(pop=0;pop<npop;pop++) {
+	   config[pop] = inconfig[pop] ;
+	   size[pop] = (cp->size)[pop] ;
+	   alphag[pop] = (cp->alphag)[pop] ;
+	   tlast[pop] = 0.0 ;
+	}
+	for(pop=ind=0;pop<npop;pop++)
+		for(j=0; j<inconfig[pop];j++,ind++) {
+			
+			chrom[ind].nseg = 1;
+			if( !(chrom[ind].pseg = (struct seg*)malloc((unsigned)sizeof(struct seg)) ))
+			  ERROR("calloc error. se1");
+
+			(chrom[ind].pseg)->beg = 0;
+			(chrom[ind].pseg)->end = nsites-1;
+			(chrom[ind].pseg)->desc = ind ;
+			chrom[ind].pop = pop ;
+			}
+	seglst[0].beg = 0;
+	if( !(seglst[0].ptree = (struct node *)calloc((unsigned)(2*nsam),sizeof(struct node)) ))
+		 perror("calloc error. se2");
+
+
+
+	nnodes[0] = nsam - 1 ;
+	nchrom = nsamin ;  /* adna */
+	nlinks = ((long)(nsamin))*(nsites-1) ;  /* adna */
+	nsegs=1;
+	t = 0.;
+	r /= (nsites-1);
+	if( f > 0.0 ) 	pc = (track_len -1.0)/track_len ;
+	else pc = 1.0 ;
+	lnpc = log( pc ) ;
+	cleft = nsamin* ( 1.0 - pow( pc, (double)(nsites-1) ) ) ; /* adna */
+	if( r > 0.0 ) rf = r*f ;
+	else rf = f /(nsites-1) ;
+	rft = rf*track_len ;
+	flagint = 0 ;
+
+/* Main loop */
+
+	while( (nchrom + numanc)  > 1 ) {   /* adna */
+		prec = nlinks*r;
+		cin = nlinks*rf ;
+		clefta = cleft*rft ;
+		prect = prec + cin + clefta ;
+		mig = 0.0;
+		for( i=0; i<npop; i++) mig += config[i]*migm[i][i] ;
+		if( (npop > 1) && ( mig == 0.0) && ( nextevent == NULL)) {
+		   i = 0;
+		   for( j=0; j<npop; j++) 
+			if( config[j] > 0 ) i++;
+		   if( i > 1 ) {
+			fprintf(stderr," Infinite coalescent time. No migration.\n");
+			exit(1);
+		   }
+		}
+		eflag = 0 ;
+
+		if( prect > 0.0 ) {      /* cross-over or gene conversion */
+		  while( (rdum = ran1() )  == 0.0 ) ;
+		  ttemp = -log( rdum)/prect ;
+		  if( (eflag == 0) || (ttemp < tmin ) ){
+		    tmin = ttemp;
+		    event = 'r' ;
+		    eflag = 1;
+		  }
+	        }
+		if(mig > 0.0 ) {         /* migration   */
+		  while( (rdum = ran1() ) == 0.0 ) ;
+		  ttemp = -log( rdum)/mig ;
+		  if( (eflag == 0) || (ttemp < tmin ) ){
+		    tmin = ttemp;
+		    event = 'm' ;
+		    eflag = 1 ;
+		  }
+	        }
+		
+	    for(pop=0; pop<npop ; pop++) {     /* coalescent */
+		coal_prob = ((double)config[pop])*(config[pop]-1.) ;
+	        if( coal_prob > 0.0 ) {
+		   while( ( rdum = ran1() )  == .0 )
+               ;
+	  	   if( alphag[pop] == 0 ){
+			 ttemp = -log( rdum )*size[pop] /coal_prob ;
+		         if( (eflag == 0) || (ttemp < tmin ) ){
+		            tmin = ttemp;
+		            event = 'c' ;
+		            eflag = 1 ;
+			    cpop = pop;
+			 }
+		    }
+	  	   else {
+		     arg  = 1. - alphag[pop]*size[pop]*exp(-alphag[pop]*(t - tlast[pop] ) )* log(rdum) / coal_prob     ;
+		     if( arg > 0.0 ) {                          /*if arg <= 0,  no coalescent within interval */ 
+		         ttemp = log( arg ) / alphag[pop]  ;
+		         if( (eflag == 0) || (ttemp < tmin ) ){
+		            tmin = ttemp;
+		            event = 'c' ;
+		            eflag = 1 ;
+			    cpop = pop ;
+			 }
+		     }
+		   }
+	         }		
+ 	      }
+
+	    if( (eflag == 0) && ( nextevent == NULL) ) {
+	      fprintf(stderr,
+               " infinite time to next event. Negative growth rate in last time interval or non-communicating subpops.\n");
+	      exit( 0);
+	    }
+	if( ( ( eflag == 0) && (nextevent != NULL))|| ( (nextevent != NULL) &&  ( (t+tmin) >=  nextevent->time)) ) {
+	    t = nextevent->time ;
+	    switch(  nextevent->detype ) {
+		case 'N' :
+		   for(pop =0; pop <npop; pop++){
+			 size[pop]= nextevent->paramv ;
+			 alphag[pop] = 0.0 ;
+			}
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'n' :
+		   size[nextevent->popi]= nextevent->paramv ;
+		   alphag[nextevent->popi] = 0.0 ;
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'G' :
+		   for(pop =0; pop <npop; pop++){
+		     size[pop] = size[pop]*exp( -alphag[pop]*(t - tlast[pop]) ) ;
+		     alphag[pop]= nextevent->paramv ;
+		     tlast[pop] = t ;
+		   }
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'g' :
+		     pop = nextevent->popi ;
+		     size[pop] = size[pop]*exp( - alphag[pop]*(t-tlast[pop]) ) ;
+		     alphag[pop]= nextevent->paramv ;
+		     tlast[pop] = t ;
+		     nextevent = nextevent->nextde ;
+		     break;
+		case 'M' :
+		   for(pop =0; pop <npop; pop++)
+		     for( pop2 = 0; pop2 <npop; pop2++) migm[pop][pop2] = (nextevent->paramv) /(npop-1.0) ;
+		   for( pop = 0; pop <npop; pop++)
+		     migm[pop][pop]= nextevent->paramv ;
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'a' :
+		   for(pop =0; pop <npop; pop++)
+		     for( pop2 = 0; pop2 <npop; pop2++) migm[pop][pop2] = (nextevent->mat)[pop][pop2]  ;
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'm' :
+		  i = nextevent->popi ;
+		  j = nextevent->popj ;
+		  migm[i][i] += nextevent->paramv - migm[i][j];
+		   migm[i][j]= nextevent->paramv ;
+		   nextevent = nextevent->nextde ;
+		   break;
+        case 'j' :         /* merge pop i into pop j  (join) */
+		  i = nextevent->popi ;
+		  j = nextevent->popj ;
+		  config[j] += config[i] ;
+		  config[i] = 0 ;
+		  for( ic = 0; ic<nchrom; ic++) if( chrom[ic].pop == i ) chrom[ic].pop = j ;
+		/*  the following was added 19 May 2007 */
+		  for( k=0; k < npop; k++){
+		     if( k != i) {
+		        migm[k][k] -= migm[k][i] ;
+		        migm[k][i] = 0. ;
+			 }
+		   }
+		/* end addition */
+		   nextevent = nextevent->nextde ;
+                break;
+        case 'A' :  /* ancient dna sample */
+                num = nextevent->num ;
+                nlinks += ((long)(num))*(nsites-1) ;
+                cleft += num* ( 1.0 - pow( pc, (double)(nsites-1) ) ) ;
+                
+                if( (nchrom + num ) >= maxchr ) {
+                    maxchr += 20 ;
+                    chrom = (struct chromo *)realloc( chrom, (unsigned)(maxchr*sizeof(struct chromo))) ;
+                    if( chrom == NULL ) perror( "malloc error. segtre2");
+                }
+ 
+                for(ind = nchrom, i= nsam - numanc   ; ind < nchrom + num ; ind++, i++) {
+                        chrom[ind].nseg = 1;
+                        if( !(chrom[ind].pseg = (struct seg*)malloc((unsigned)sizeof(struct seg)) ))
+                            ERROR("calloc error. se1");
+                        (chrom[ind].pseg)->beg = 0;
+                        (chrom[ind].pseg)->end = nsites-1;
+                        (chrom[ind].pseg)->desc = i ;
+                        chrom[ind].pop = nextevent->popi ;
+                    }
+                ptree1 = seglst[0].ptree ;
+                for( i= nsam - numanc  ; i<  nsam -numanc +num  ;  i++){
+                    (ptree1+i)->time = t ;
+                }
+                nchrom += num;
+                config[ nextevent->popi] += num ;
+                numanc -= num ;
+                nextevent = nextevent->nextde ;
+                break;
+        case 's' :         /*split  pop i into two;p is the proportion from pop i, and 1-p from pop n+1  */
+		  i = nextevent->popi ;
+		  p = nextevent->paramv ;
+		  npop++;
+		  config = (int *)realloc( config, (unsigned)(npop*sizeof( int) )); 
+		  size = (double *)realloc(size, (unsigned)(npop*sizeof(double) ));
+		  alphag = (double *)realloc(alphag, (unsigned)(npop*sizeof(double) ));
+		  tlast = (double *)realloc(tlast,(unsigned)(npop*sizeof(double) ) ) ;
+		  tlast[npop-1] = t ;
+		  size[npop-1] = 1.0 ;
+		  alphag[npop-1] = 0.0 ;
+		  migm = (double **)realloc(migm, (unsigned)(npop*sizeof( double *)));
+		  for( j=0; j< npop-1; j++)
+			 migm[j] = (double *)realloc(migm[j],(unsigned)(npop*sizeof(double)));
+		  migm[npop-1] = (double *)malloc( (unsigned)(npop*sizeof( double) ) ) ;
+		  for( j=0; j<npop; j++) migm[npop-1][j] = migm[j][npop-1] = 0.0 ;
+		  config[npop-1] = 0 ;
+		  config[i] = 0 ;
+		  for( ic = 0; ic<nchrom; ic++){
+		    if( chrom[ic].pop == i ) {
+		      if( ran1() < p ) config[i]++;
+		      else {
+			 chrom[ic].pop = npop-1 ;
+			 config[npop-1]++;
+		      }
+		    }
+		  }
+		   nextevent = nextevent->nextde ;
+		   break;
+		}
+ 	   } 
+	else {
+		   t += tmin ;	
+		   if( event == 'r' ) {   
+		      if( (ran = ran1()) < ( prec / prect ) ){ /*recombination*/
+		     	  rchrom = re(nsam);
+			  config[ chrom[rchrom].pop ] += 1 ;
+		      }
+		      else if( ran < (prec + clefta)/(prect) ){    /*  cleft event */
+			 rchrom = cleftr(nsam);
+			 config[ chrom[rchrom].pop ] += 1 ;
+		      }
+		      else  {         /* cin event */
+			 rchrom = cinr(nsam,nsites);
+			 if( rchrom >= 0 ) config[ chrom[rchrom].pop ] += 1 ;
+		      }
+		   }
+	           else if ( event == 'm' ) {  /* migration event */
+			x = mig*ran1();
+			sum = 0.0 ;
+			for( i=0; i<nchrom; i++) {
+			  sum += migm[chrom[i].pop][chrom[i].pop] ;
+			  if( x <sum ) break;
+			  }
+			migrant = i ;
+			x = ran1()*migm[chrom[i].pop][chrom[i].pop];
+			sum = 0.0;
+			for(i=0; i<npop; i++){
+			  if( i != chrom[migrant].pop ){
+			    sum += migm[chrom[migrant].pop][i];
+			    if( x < sum ) break;
+			   }
+			}
+			source_pop = i;
+			  config[chrom[migrant].pop] -= 1;
+			  config[source_pop] += 1;
+			  chrom[migrant].pop = source_pop ;
+	           }
+		   else { 								 /* coalescent event */
+			/* pick the two, c1, c2  */
+			pick2_chrom( cpop, config, &c1,&c2);  /* c1 and c2 are chrom's to coalesce */
+			dec = ca(nsam,nsites,c1,c2 );
+			config[cpop] -= dec ;
+		   }
+		 }
+	     }
+ /* adna */
+    if( nsegs >1 ){
+        ptree0 = seglst[0].ptree ;
+        for( seg=seglst[0].next, k=1; k<nsegs; seg=seglst[seg].next, k++) {
+            ptree1 = seglst[seg].ptree ;
+            for( i= nsamin; i< nsam; i++) (ptree1+i)->time = (ptree0+i)->time ;
+        }
+    }
+
+    
+	*pnsegs = nsegs ;
+	free(config); 
+	free( size ) ;
+	free( alphag );
+	free( tlast );
+	for( i=0; i<npop; i++) free ( migm[i] ) ;
+	free( migm ) ;
+	return( seglst );
+}
+
+/******  recombination subroutine ***************************
+   Picks a chromosome and splits it in two parts. If the x-over point
+   is in a new spot, a new segment is added to seglst and a tree set up
+   for it.   ****/
+
+
+	int
+re(nsam)
+	int nsam;
+{
+	struct seg *pseg ;
+	int  el, lsg, lsgm1,  ic,  is, in;
+    long spot;
+	double ran1();
+
+
+/* First generate a random x-over spot, then locate it as to chrom and seg. */
+
+	spot = nlinks*ran1() + 1.;
+
+    /* get chromosome # (ic)  */
+
+	for( ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);
+		if( spot <= el ) break;
+		spot -= el ;
+		}
+	is = pseg->beg + spot -1;
+	xover(nsam, ic, is);
+	return(ic);	
+}
+
+	int
+cleftr( int nsam)
+{
+	struct seg *pseg ;
+	int   lsg, lsgm1,  ic,  is, in, spot;
+	double ran1(), x, sum, len  ;
+
+    while( (x = cleft*ran1() )== 0.0 )
+       ;
+	sum = 0.0 ;
+	ic = -1 ;
+	while ( sum < x ) {
+		sum +=  1.0 - pow( pc, links(++ic) )  ;
+		}
+	pseg = chrom[ic].pseg;
+	len = links(ic) ;
+	is = pseg->beg + floor( 1.0 + log( 1.0 - (1.0- pow( pc, len))*ran1() )/lnpc  ) -1  ;
+	xover( nsam, ic, is);
+	return( ic) ;
+}
+
+	int
+cinr( int nsam, int nsites)
+{
+	struct seg *pseg ;
+	int len,  el, lsg, lsgm1,  ic,  is, in, spot, endic ;
+	double ran1();
+	int  ca() ;
+
+
+/* First generate a random x-over spot, then locate it as to chrom and seg. */
+
+	spot = nlinks*ran1() + 1.;
+
+    /* get chromosome # (ic)  */
+
+	for( ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);
+		if( spot <= el ) break;
+		spot -= el ;
+		}
+	is = pseg->beg + spot -1;
+	endic = (pseg+lsgm1)->end ;
+	xover(nsam, ic, is);
+
+	len = floor( 1.0 + log( ran1() )/lnpc ) ;
+	if( is+len >= endic ) return(ic) ;  
+	if( is+len < (chrom[nchrom-1].pseg)->beg ){
+	   ca( nsam, nsites, ic, nchrom-1);
+	    return(-1) ;
+	    }
+	xover( nsam, nchrom-1, is+len ) ;
+	ca( nsam,nsites, ic,  nchrom-1);
+	return(ic);	
+
+}
+
+	int
+xover(int nsam,int ic, int is)
+{
+	struct seg *pseg, *pseg2;
+	int i,  lsg, lsgm1, newsg,  jseg, k,  in, spot;
+	double ran1(), len ;
+
+
+	pseg = chrom[ic].pseg ;
+	lsg = chrom[ic].nseg ;
+	len = (pseg + lsg -1)->end - pseg->beg ;
+	cleft -= 1 - pow(pc,len) ;
+   /* get seg # (jseg)  */
+
+	for( jseg=0; is >= (pseg+jseg)->end ; jseg++) ;
+	if( is >= (pseg+jseg)->beg ) in=1;
+	else in=0;
+	newsg = lsg - jseg ;
+
+   /* copy last part of chrom to nchrom  */
+
+	nchrom++;
+	if( nchrom >= maxchr ) {
+	    maxchr += 20 ;
+	    chrom = (struct chromo *)realloc( chrom, (unsigned)(maxchr*sizeof(struct chromo))) ;
+	    if( chrom == NULL ) perror( "malloc error. segtre2");
+	    }
+	if( !( pseg2 = chrom[nchrom-1].pseg = (struct seg *)calloc((unsigned)newsg,sizeof(struct seg)) ) )
+		ERROR(" alloc error. re1");
+	chrom[nchrom-1].nseg = newsg;
+	chrom[nchrom-1].pop = chrom[ic].pop ;
+	pseg2->end = (pseg+jseg)->end ;
+	if( in ) {
+		pseg2->beg = is + 1 ;
+		(pseg+jseg)->end = is;
+		}
+	else pseg2->beg = (pseg+jseg)->beg ;
+	pseg2->desc = (pseg+jseg)->desc ;
+	for( k=1; k < newsg; k++ ) {
+		(pseg2+k)->beg = (pseg+jseg+k)->beg;
+		(pseg2+k)->end = (pseg+jseg+k)->end;
+		(pseg2+k)->desc = (pseg+jseg+k)->desc;
+		}
+
+	lsg = chrom[ic].nseg = lsg-newsg + in ;
+	lsgm1 = lsg - 1 ;
+	nlinks -= pseg2->beg - (pseg+lsgm1)->end ;
+	len = (pseg+lsgm1)->end - (pseg->beg) ;
+	cleft += 1.0 - pow( pc, len) ;
+	len = (pseg2 + newsg-1)->end - pseg2->beg ;
+	cleft += 1.0 - pow(pc, len) ;
+if( !(chrom[ic].pseg = 
+     (struct seg *)realloc(chrom[ic].pseg,(unsigned)(lsg*sizeof(struct seg)) )) )
+		perror( " realloc error. re2");
+	if( in ) {
+		begs = pseg2->beg;
+		for( i=0,k=0; (k<nsegs-1)&&(begs > seglst[seglst[i].next].beg-1);
+		   i=seglst[i].next, k++) ;
+		if( begs != seglst[i].beg ) {
+						/* new tree  */
+
+	   	   if( nsegs >= seglimit ) {  
+	   	   	  seglimit += SEGINC ;
+	   	      nnodes = (int *)realloc( nnodes,(unsigned)(sizeof(int)*seglimit)) ; 
+	   	      if( nnodes == NULL) perror("realloc error. 1. segtre_mig.c");
+	   	      seglst =
+	   	      	 (struct segl *)realloc( seglst,(unsigned)(sizeof(struct segl)*seglimit));
+	   	      if(seglst == NULL ) perror("realloc error. 2. segtre_mig.c");
+	   	      /*  printf("seglimit: %d\n",seglimit);  */
+	   	      } 
+	   	   seglst[nsegs].next = seglst[i].next;
+	   	   seglst[i].next = nsegs;
+	   	   seglst[nsegs].beg = begs ;
+		   if( !(seglst[nsegs].ptree = (struct node *)calloc((unsigned)(2*nsam), sizeof(struct
+			 node)) )) perror("calloc error. re3.");
+		   nnodes[nsegs] = nnodes[i];
+		   ptree1 = seglst[i].ptree;
+		   ptree2 = seglst[nsegs].ptree;
+		   nsegs++ ;
+		   for( k=0; k<=nnodes[i]; k++) {
+		      (ptree2+k)->abv = (ptree1+k)->abv ;
+		      (ptree2+k)->time = (ptree1+k)->time;
+		      }
+		   }
+	}
+	return(ic) ;
+}
+
+/***** common ancestor subroutine **********************
+   Pick two chromosomes and merge them. Update trees if necessary. **/
+
+	int
+ca(int nsam, int nsites, int c1, int c2)
+{
+	int yes1, yes2, seg1, seg2, seg ;
+	int tseg, start, end, desc, k;
+	struct seg *pseg;
+	struct node *ptree;
+    int isseg(int start, int c, int *psg);
+
+	seg1=0;
+	seg2=0;
+
+	if( !(pseg = (struct seg *)calloc((unsigned)nsegs,sizeof(struct seg) ))) 
+		perror("alloc error.ca1");
+
+	tseg = -1 ;
+
+	for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
+		start = seglst[seg].beg;
+		yes1 = isseg(start, c1, &seg1);
+		yes2 = isseg(start, c2, &seg2);
+		if( yes1 || yes2 ) {
+			tseg++;
+			(pseg+tseg)->beg=seglst[seg].beg;
+			end = ( k< nsegs-1 ? seglst[seglst[seg].next].beg-1 : nsites-1 ) ;
+			(pseg+tseg)->end = end ;
+
+			if( yes1 && yes2 ) {
+				nnodes[seg]++;
+				if( nnodes[seg] >= (2*nsam-2) ) tseg--;
+				else
+					(pseg+tseg)->desc = nnodes[seg];
+				ptree=seglst[seg].ptree;
+				desc = (chrom[c1].pseg + seg1) ->desc;
+				(ptree+desc)->abv = nnodes[seg];
+				desc = (chrom[c2].pseg + seg2) -> desc;
+				(ptree+desc)->abv = nnodes[seg];
+				(ptree+nnodes[seg])->time = t;
+
+				}
+			else {
+				(pseg+tseg)->desc = ( yes1 ?
+				   (chrom[c1].pseg + seg1)->desc :
+				  (chrom[c2].pseg + seg2)->desc);
+				}
+			}
+		}
+	nlinks -= links(c1);
+	cleft -= 1.0 - pow(pc, (double)links(c1));
+	free(chrom[c1].pseg) ;
+	if( tseg < 0 ) {
+		free(pseg) ;
+		chrom[c1].pseg = chrom[nchrom-1].pseg;
+		chrom[c1].nseg = chrom[nchrom-1].nseg;
+		chrom[c1].pop = chrom[nchrom-1].pop ;
+		if( c2 == nchrom-1 ) c2 = c1;
+		nchrom--;
+		}
+	else {
+		if( !(pseg = (struct seg *)realloc(pseg,(unsigned)((tseg+1)*sizeof(struct seg)))))
+			perror(" realloc error. ca1");
+		chrom[c1].pseg = pseg;
+		chrom[c1].nseg = tseg + 1 ;
+		nlinks += links(c1);
+	   	cleft += 1.0 - pow(pc, (double)links(c1));
+		}
+	nlinks -= links(c2);
+	cleft -= 1.0 - pow(pc, (double)links(c2));
+	free(chrom[c2].pseg) ;
+	chrom[c2].pseg = chrom[nchrom-1].pseg;
+	chrom[c2].nseg = chrom[nchrom-1].nseg;
+	chrom[c2].pop = chrom[nchrom-1].pop ;
+	nchrom--;
+	if(tseg<0) return( 2 );  /* decrease of nchrom is two */
+	else return( 1 ) ;
+}
+
+/*** Isseg: Does chromosome c contain the segment on seglst which starts at
+	    start? *psg is the segment of chrom[c] at which one is to begin 
+	    looking.  **/
+
+	int
+isseg(int start, int c, int *psg)
+{
+	int ns;
+	struct seg *pseg;
+
+	ns = chrom[c].nseg;
+	pseg = chrom[c].pseg;
+
+/*  changed order of test conditions in following line on 6 Dec 2004 */
+	for(  ; ((*psg) < ns ) && ( (pseg+(*psg))->beg <= start ) ; ++(*psg) )
+		if( (pseg+(*psg))->end >= start ) return(1);
+	return(0);
+}
+	
+
+
+	void
+pick2_chrom(int pop,int config[], int *pc1, int *pc2)
+{
+	int c1, c2, cs,cb,i, count;
+	
+	pick2(config[pop],&c1,&c2);
+	cs = (c1>c2) ? c2 : c1;
+	cb = (c1>c2) ? c1 : c2 ;
+	i=count=0;
+	for(;;){
+		while( chrom[i].pop != pop ) i++;
+		if( count == cs ) break;
+		count++;
+		i++;
+		}
+	*pc1 = i;
+	i++;
+	count++;
+	for(;;){
+		while( chrom[i].pop != pop ) i++;
+		if( count == cb ) break;
+		count++;
+		i++;
+		}
+	*pc2 = i ;
+}
+	
+	
+
+/****  links(c): returns the number of links between beginning and end of chrom **/
+
+	int
+links(int c)
+{
+	int ns;
+
+	ns = chrom[c].nseg - 1 ;
+
+	return( (chrom[c].pseg + ns)->end - (chrom[c].pseg)->beg);
+}
+


### PR DESCRIPTION
Added new `evaluation` directory, with a `Makefile` that installs and builds other simulators:
- ms
- msms
- scrm
- discoal
- ARGON

and pip installs the version of msprime in the `requirements.txt` file. Currently, this points to msprime master.

This also contains scripts to run comparisons of these tools against msprime as discussed in #4 . Parameters are not finalized and not yet implemented in the case of selective sweeps. This PR is primarily to get the pipeline in.