### PR TITLE
Make figures dir

### DIFF
--- a/figures/.gitignore
+++ b/figures/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
`make` requires the figures dir to be present. This forces it to be created on GitHub.