### PR TITLE
Add example ts figure and restructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ DATA=data/arg.csv\
 FIGURES=figures/mutations-perf.pdf\
 	figures/arg.pdf\
 	figures/sweeps-perf.pdf\
-	figures/gc-perf.pdf
+	figures/gc-perf.pdf\
+	figures/example_tree_sequence.pdf
 
 paper.pdf: paper.tex paper.bib ${DATA} ${FIGURES}
 	pdflatex paper.tex
@@ -14,6 +15,9 @@ paper.pdf: paper.tex paper.bib ${DATA} ${FIGURES}
 
 figures/%.pdf:
 	python3 evaluation/plot.py $*
+
+figures/example_tree_sequence.pdf: figures/example_tree_sequence.ink.svg
+	inkscape $< --export-pdf=$@
 
 data/arg.csv:
 	python3 evaluation/generate_arg_data.py

--- a/figures/example_tree_sequence.ink.svg
+++ b/figures/example_tree_sequence.ink.svg
@@ -1,0 +1,4932 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   xml:space="preserve"
+   width="517.52673"
+   height="271.48798"
+   viewBox="0 0 517.52674 271.48797"
+   sodipodi:docname="example_tree_sequence.ink.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+     id="metadata8"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+     id="defs6"><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker4593"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="Arrow1Mstart"><path
+     transform="matrix(0.4,0,0,0.4,4,0)"
+     style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     id="path4591"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="Arrow1Mstart"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="Arrow1Mstart"
+   style="overflow:visible"
+   inkscape:isstock="true"
+   inkscape:collect="always"><path
+     id="path4045"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(0.4,0,0,0.4,4,0)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="Arrow1Mend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker3159"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path3157"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="Arrow1Mend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker2883"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path2881"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="Arrow1Mend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker2603"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path2601"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="Arrow1Mend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker8262"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     inkscape:connector-curvature="0"
+     id="path8260"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)" /></marker><marker
+   inkscape:stockid="Arrow1Mend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker7958"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     inkscape:connector-curvature="0"
+     id="path7956"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker7666"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="Arrow1Mend"
+   inkscape:collect="always"><path
+     inkscape:connector-curvature="0"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     id="path7664" /></marker><marker
+   inkscape:stockid="Arrow1Mend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker7368"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     inkscape:connector-curvature="0"
+     id="path7366"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)" /></marker><marker
+   inkscape:stockid="Arrow1Mend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker7088"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     inkscape:connector-curvature="0"
+     id="path7086"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)" /></marker><marker
+   inkscape:stockid="Arrow1Mend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker6805"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     inkscape:connector-curvature="0"
+     id="path6803"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.4,0,0,-0.4,-4,0)" /></marker><marker
+   inkscape:stockid="StopL"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker6462"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     inkscape:connector-curvature="0"
+     id="path6460"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.8)" /></marker><marker
+   inkscape:stockid="StopL"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker6206"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     inkscape:connector-curvature="0"
+     id="path6204"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.8)" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker11204"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path11202"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker10960"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path10958"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker10722"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path10720"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopL"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker10390"
+   style="overflow:visible"
+   inkscape:isstock="true"
+   inkscape:collect="always"><path
+     id="path10388"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.8)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopL"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker10146"
+   style="overflow:visible"
+   inkscape:isstock="true"
+   inkscape:collect="always"><path
+     id="path10144"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.8)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker8862"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"
+   inkscape:collect="always"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path8860"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker8666"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path8664"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker8656"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path8654"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker8646"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path8644"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopL"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker8434"
+   style="overflow:visible"
+   inkscape:isstock="true"
+   inkscape:collect="always"><path
+     id="path8432"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.8)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker8226"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path8224"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker8042"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path8040"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker7864"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path7862"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker7692"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopL"><path
+     transform="scale(0.8)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path7690"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopL"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="StopL"
+   style="overflow:visible"
+   inkscape:isstock="true"
+   inkscape:collect="always"><path
+     id="path3777"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.8)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopM"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker7190"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path7188"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.4)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopM"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker7042"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path7040"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.4)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopM"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker6900"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path6898"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.4)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopM"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker6884"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path6882"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.4)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopM"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker6748"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path6746"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.4)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker6674"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="DotM"><path
+     transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+     id="path6672"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker6664"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="DotM"><path
+     transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+     id="path6662"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker6654"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="DotM"><path
+     transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+     id="path6652"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker6644"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="DotM"><path
+     transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+     id="path6642"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker6634"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="DotM"><path
+     transform="matrix(0.4,0,0,0.4,2.96,0.4)"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+     id="path6632"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopM"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker6268"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path6266"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.4)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopM"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="marker6150"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path6148"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.4)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="Arrow1Lend"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="Arrow1Lend"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path3611"
+     d="M 0,0 5,-5 -12.5,0 5,5 Z"
+     style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(-0.8,0,0,-0.8,-10,0)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker4100"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopM"><path
+     transform="scale(0.4)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path4098"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:isstock="true"
+   style="overflow:visible"
+   id="marker4060"
+   refX="0"
+   refY="0"
+   orient="auto"
+   inkscape:stockid="StopM"><path
+     transform="scale(0.4)"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     d="M 0,5.65 V -5.65"
+     id="path4058"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="StopM"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="StopM"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path3780"
+     d="M 0,5.65 V -5.65"
+     style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="scale(0.4)"
+     inkscape:connector-curvature="0" /></marker><marker
+   inkscape:stockid="DotL"
+   orient="auto"
+   refY="0"
+   refX="0"
+   id="DotL"
+   style="overflow:visible"
+   inkscape:isstock="true"><path
+     id="path3669"
+     d="m -2.5,-1 c 0,2.76 -2.24,5 -5,5 -2.76,0 -5,-2.24 -5,-5 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 z"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+     transform="matrix(0.8,0,0,0.8,5.92,0.8)"
+     inkscape:connector-curvature="0" /></marker>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</defs><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview4"
+     showgrid="true"
+     inkscape:zoom="1.1737709"
+     inkscape:cx="333.07667"
+     inkscape:cy="174.39804"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-global="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"><inkscape:grid
+       type="xygrid"
+       id="grid466"
+       originx="-23.346868"
+       originy="0.49997757" /></sodipodi:namedview><g
+     id="g10"
+     inkscape:groupmode="layer"
+     inkscape:label="example_tree_sequence"
+     transform="matrix(1.3333333,0,0,-1.3333333,-23.346868,270.98799)"
+     style="display:none"><g
+       id="g12"
+       transform="scale(0.1)"><path
+         d="M 389.18,329.406 H 4924.5 v 1559.02 H 389.18 Z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path14"
+         inkscape:connector-curvature="0" /><path
+         d="M 2089.93,329.406 V 1888.42"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path16"
+         inkscape:connector-curvature="0" /><path
+         d="M 2656.84,329.406 V 1888.42"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path18"
+         inkscape:connector-curvature="0" /><path
+         d="M 389.18,1038.05 H 2089.93"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path20"
+         inkscape:connector-curvature="0" /><path
+         d="M 3790.67,329.406 V 1888.42"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path22"
+         inkscape:connector-curvature="0" /><path
+         d="M 2089.93,1782.12 H 4924.5"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path24"
+         inkscape:connector-curvature="0" /><path
+         d="M 3790.67,1179.78 H 4924.5"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path26"
+         inkscape:connector-curvature="0" /><path
+         d="M 3790.67,1073.48 H 4924.5"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path28"
+         inkscape:connector-curvature="0" /><path
+         d="M 530.91,187.68 H 1948.2"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path30"
+         inkscape:connector-curvature="0" /><path
+         d="M 530.91,216.023 V 159.332"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path32"
+         inkscape:connector-curvature="0" /><path
+         d="M 1239.55,216.023 V 159.332"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path34"
+         inkscape:connector-curvature="0" /><path
+         d="M 1948.2,216.023 V 159.332"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path36"
+         inkscape:connector-curvature="0" /><path
+         d="m 860.176,162.625 h 50.1094 v 50.1094 H 860.176 Z"
+         style="fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path38"
+         inkscape:connector-curvature="0" /><path
+         d="m 860.176,162.625 h 50.1094 v 50.1094 H 860.176 Z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path40"
+         inkscape:connector-curvature="0" /><path
+         d="m 1568.82,162.625 h 50.1094 v 50.1094 H 1568.82 Z"
+         style="fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path42"
+         inkscape:connector-curvature="0" /><path
+         d="m 1568.82,162.625 h 50.1094 v 50.1094 H 1568.82 Z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path44"
+         inkscape:connector-curvature="0" /><path
+         d="M 672.637,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path46"
+         inkscape:connector-curvature="0" /><path
+         d="M 814.367,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path48"
+         inkscape:connector-curvature="0" /><path
+         d="M 956.098,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path50"
+         inkscape:connector-curvature="0" /><path
+         d="M 1097.82,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path52"
+         inkscape:connector-curvature="0" /><path
+         d="M 1239.55,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path54"
+         inkscape:connector-curvature="0" /><path
+         d="M 1381.28,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path56"
+         inkscape:connector-curvature="0" /><path
+         d="M 1523.01,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path58"
+         inkscape:connector-curvature="0" /><path
+         d="M 1664.74,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path60"
+         inkscape:connector-curvature="0" /><path
+         d="M 1806.47,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path62"
+         inkscape:connector-curvature="0" /><path
+         d="M 1948.2,201.852 V 173.504"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path64"
+         inkscape:connector-curvature="0" /><path
+         d="m 233.277,1321.51 h 28.348"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path66"
+         inkscape:connector-curvature="0" /><path
+         d="m 233.277,1505.75 h 28.348"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path68"
+         inkscape:connector-curvature="0" /><path
+         d="m 233.277,1690 h 28.348"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path70"
+         inkscape:connector-curvature="0" /><path
+         d="M 247.453,1690 V 1321.51"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path72"
+         inkscape:connector-curvature="0" /><path
+         d="M 530.91,896.32 H 1948.2"
+         style="fill:none;stroke:#000000;stroke-width:9.99975014;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path74"
+         inkscape:connector-curvature="0" /><path
+         d="m 530.91,896.32 v 0"
+         style="fill:none;stroke:#000000;stroke-width:29.99920082;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path76"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,896.32 c 0,6.907 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.598 12.5,12.5"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path78"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,896.32 c 0,6.907 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.598 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path80"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,896.32 c 0,6.907 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.598 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path82"
+         inkscape:connector-curvature="0" /><path
+         d="m 1136.55,949.82 v 34.731 c 0,10.652 8.63,19.289 19.28,19.289 h 25.71 c 10.66,0 19.29,-8.637 19.29,-19.289 V 949.82 c 0,-10.652 -8.63,-19.285 -19.29,-19.285 h -25.71 c -10.65,0 -19.28,8.633 -19.28,19.285"
+         style="fill:#c54c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path84"
+         inkscape:connector-curvature="0" /><path
+         d="m 1136.55,949.82 v 34.731 c 0,10.652 8.63,19.289 19.28,19.289 h 25.71 c 10.66,0 19.29,-8.637 19.29,-19.289 V 949.82 c 0,-10.652 -8.63,-19.285 -19.29,-19.285 h -25.71 c -10.65,0 -19.28,8.633 -19.28,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path86"
+         inkscape:connector-curvature="0" /><path
+         d="m 1239.55,967.188 h -28.34"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path88"
+         inkscape:connector-curvature="0" /><path
+         d="m 1267.9,967.188 -28.35,7.593 V 959.59 l 28.35,7.598"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path90"
+         inkscape:connector-curvature="0" /><path
+         d="m 1267.9,967.188 -28.35,7.593 V 959.59 Z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path92"
+         inkscape:connector-curvature="0" /><path
+         d="m 1278.28,949.82 v 34.731 c 0,10.652 8.63,19.289 19.28,19.289 h 25.71 c 10.66,0 19.29,-8.637 19.29,-19.289 V 949.82 c 0,-10.652 -8.63,-19.285 -19.29,-19.285 h -25.71 c -10.65,0 -19.28,8.633 -19.28,19.285"
+         style="fill:#4a907f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path94"
+         inkscape:connector-curvature="0" /><path
+         d="m 1278.28,949.82 v 34.731 c 0,10.652 8.63,19.289 19.28,19.289 h 25.71 c 10.66,0 19.29,-8.637 19.29,-19.289 V 949.82 c 0,-10.652 -8.63,-19.285 -19.29,-19.285 h -25.71 c -10.65,0 -19.28,8.633 -19.28,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path96"
+         inkscape:connector-curvature="0" /><path
+         d="M 530.91,754.594 H 1948.2"
+         style="fill:none;stroke:#000000;stroke-width:9.99975014;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path98"
+         inkscape:connector-curvature="0" /><path
+         d="m 530.91,754.594 v 0"
+         style="fill:none;stroke:#000000;stroke-width:29.99920082;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path100"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,754.594 c 0,6.902 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.598 -12.5,-12.5 0,-6.903 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.597 12.5,12.5"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path102"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,754.594 c 0,6.902 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.598 -12.5,-12.5 0,-6.903 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.597 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path104"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,754.594 c 0,6.902 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.598 -12.5,-12.5 0,-6.903 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.597 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path106"
+         inkscape:connector-curvature="0" /><path
+         d="m 1136.55,808.09 v 34.734 c 0,10.649 8.63,19.285 19.28,19.285 h 25.71 c 10.66,0 19.29,-8.636 19.29,-19.285 V 808.09 c 0,-10.649 -8.63,-19.281 -19.29,-19.281 h -25.71 c -10.65,0 -19.28,8.632 -19.28,19.281"
+         style="fill:#4a907f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path108"
+         inkscape:connector-curvature="0" /><path
+         d="m 1136.55,808.09 v 34.734 c 0,10.649 8.63,19.285 19.28,19.285 h 25.71 c 10.66,0 19.29,-8.636 19.29,-19.285 V 808.09 c 0,-10.649 -8.63,-19.281 -19.29,-19.281 h -25.71 c -10.65,0 -19.28,8.632 -19.28,19.281 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path110"
+         inkscape:connector-curvature="0" /><path
+         d="m 1239.55,825.457 h -28.34"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path112"
+         inkscape:connector-curvature="0" /><path
+         d="m 1267.9,825.457 -28.35,7.594 v -15.188 l 28.35,7.594"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path114"
+         inkscape:connector-curvature="0" /><path
+         d="m 1267.9,825.457 -28.35,7.594 v -15.188 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path116"
+         inkscape:connector-curvature="0" /><path
+         d="m 1278.28,808.09 v 34.734 c 0,10.649 8.63,19.285 19.28,19.285 h 25.71 c 10.66,0 19.29,-8.636 19.29,-19.285 V 808.09 c 0,-10.649 -8.63,-19.281 -19.29,-19.281 h -25.71 c -10.65,0 -19.28,8.632 -19.28,19.281"
+         style="fill:#6f84bd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path118"
+         inkscape:connector-curvature="0" /><path
+         d="m 1278.28,808.09 v 34.734 c 0,10.649 8.63,19.285 19.28,19.285 h 25.71 c 10.66,0 19.29,-8.636 19.29,-19.285 V 808.09 c 0,-10.649 -8.63,-19.281 -19.29,-19.281 h -25.71 c -10.65,0 -19.28,8.632 -19.28,19.281 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path120"
+         inkscape:connector-curvature="0" /><path
+         d="m 530.91,612.863 h 708.64"
+         style="fill:none;stroke:#000000;stroke-width:9.99975014;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path122"
+         inkscape:connector-curvature="0" /><path
+         d="m 530.91,612.863 v 0"
+         style="fill:none;stroke:#000000;stroke-width:29.99920082;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path124"
+         inkscape:connector-curvature="0" /><path
+         d="m 1252.05,612.863 c 0,6.907 -5.59,12.5 -12.5,12.5 -6.9,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.6,-12.5 12.5,-12.5 6.91,0 12.5,5.598 12.5,12.5"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path126"
+         inkscape:connector-curvature="0" /><path
+         d="m 1252.05,612.863 c 0,6.907 -5.59,12.5 -12.5,12.5 -6.9,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.6,-12.5 12.5,-12.5 6.91,0 12.5,5.598 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path128"
+         inkscape:connector-curvature="0" /><path
+         d="m 1252.05,612.863 c 0,6.907 -5.59,12.5 -12.5,12.5 -6.9,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.6,-12.5 12.5,-12.5 6.91,0 12.5,5.598 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path130"
+         inkscape:connector-curvature="0" /><path
+         d="m 782.227,666.363 v 34.731 c 0,10.652 8.632,19.285 19.285,19.285 h 25.711 c 10.652,0 19.285,-8.633 19.285,-19.285 v -34.731 c 0,-10.652 -8.633,-19.285 -19.285,-19.285 h -25.711 c -10.653,0 -19.285,8.633 -19.285,19.285"
+         style="fill:#b061d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path132"
+         inkscape:connector-curvature="0" /><path
+         d="m 782.227,666.363 v 34.731 c 0,10.652 8.632,19.285 19.285,19.285 h 25.711 c 10.652,0 19.285,-8.633 19.285,-19.285 v -34.731 c 0,-10.652 -8.633,-19.285 -19.285,-19.285 h -25.711 c -10.653,0 -19.285,8.633 -19.285,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path134"
+         inkscape:connector-curvature="0" /><path
+         d="M 885.23,683.73 H 856.887"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path136"
+         inkscape:connector-curvature="0" /><path
+         d="m 913.578,683.73 -28.348,7.594 v -15.191 l 28.348,7.597"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path138"
+         inkscape:connector-curvature="0" /><path
+         d="m 913.578,683.73 -28.348,7.594 v -15.191 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path140"
+         inkscape:connector-curvature="0" /><path
+         d="m 923.957,666.363 v 34.731 c 0,10.652 8.633,19.285 19.281,19.285 h 25.715 c 10.649,0 19.281,-8.633 19.281,-19.285 v -34.731 c 0,-10.652 -8.632,-19.285 -19.281,-19.285 h -25.715 c -10.648,0 -19.281,8.633 -19.281,19.285"
+         style="fill:#4a907f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path142"
+         inkscape:connector-curvature="0" /><path
+         d="m 923.957,666.363 v 34.731 c 0,10.652 8.633,19.285 19.281,19.285 h 25.715 c 10.649,0 19.281,-8.633 19.281,-19.285 v -34.731 c 0,-10.652 -8.632,-19.285 -19.281,-19.285 h -25.715 c -10.648,0 -19.281,8.633 -19.281,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path144"
+         inkscape:connector-curvature="0" /><path
+         d="m 530.91,471.137 h 708.64"
+         style="fill:none;stroke:#000000;stroke-width:9.99975014;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path146"
+         inkscape:connector-curvature="0" /><path
+         d="m 530.91,471.137 v 0"
+         style="fill:none;stroke:#000000;stroke-width:29.99920082;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path148"
+         inkscape:connector-curvature="0" /><path
+         d="m 1252.05,471.137 c 0,6.902 -5.59,12.5 -12.5,12.5 -6.9,0 -12.5,-5.598 -12.5,-12.5 0,-6.907 5.6,-12.5 12.5,-12.5 6.91,0 12.5,5.593 12.5,12.5"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path150"
+         inkscape:connector-curvature="0" /><path
+         d="m 1252.05,471.137 c 0,6.902 -5.59,12.5 -12.5,12.5 -6.9,0 -12.5,-5.598 -12.5,-12.5 0,-6.907 5.6,-12.5 12.5,-12.5 6.91,0 12.5,5.593 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path152"
+         inkscape:connector-curvature="0" /><path
+         d="m 1252.05,471.137 c 0,6.902 -5.59,12.5 -12.5,12.5 -6.9,0 -12.5,-5.598 -12.5,-12.5 0,-6.907 5.6,-12.5 12.5,-12.5 6.91,0 12.5,5.593 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path154"
+         inkscape:connector-curvature="0" /><path
+         d="m 782.227,524.633 v 34.734 c 0,10.649 8.632,19.285 19.285,19.285 h 25.711 c 10.652,0 19.285,-8.636 19.285,-19.285 v -34.734 c 0,-10.649 -8.633,-19.285 -19.285,-19.285 h -25.711 c -10.653,0 -19.285,8.636 -19.285,19.285"
+         style="fill:#6aa944;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path156"
+         inkscape:connector-curvature="0" /><path
+         d="m 782.227,524.633 v 34.734 c 0,10.649 8.632,19.285 19.285,19.285 h 25.711 c 10.652,0 19.285,-8.636 19.285,-19.285 v -34.734 c 0,-10.649 -8.633,-19.285 -19.285,-19.285 h -25.711 c -10.653,0 -19.285,8.636 -19.285,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path158"
+         inkscape:connector-curvature="0" /><path
+         d="M 885.23,542 H 856.887"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path160"
+         inkscape:connector-curvature="0" /><path
+         d="m 913.578,542 -28.348,7.594 V 534.406 L 913.578,542"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path162"
+         inkscape:connector-curvature="0" /><path
+         d="m 913.578,542 -28.348,7.594 v -15.188 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path164"
+         inkscape:connector-curvature="0" /><path
+         d="m 923.957,524.633 v 34.734 c 0,10.649 8.633,19.285 19.281,19.285 h 25.715 c 10.649,0 19.281,-8.636 19.281,-19.285 v -34.734 c 0,-10.649 -8.632,-19.285 -19.281,-19.285 h -25.715 c -10.648,0 -19.281,8.636 -19.281,19.285"
+         style="fill:#6f84bd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path166"
+         inkscape:connector-curvature="0" /><path
+         d="m 923.957,524.633 v 34.734 c 0,10.649 8.633,19.285 19.281,19.285 h 25.715 c 10.649,0 19.281,-8.636 19.281,-19.285 v -34.734 c 0,-10.649 -8.632,-19.285 -19.281,-19.285 h -25.715 c -10.648,0 -19.281,8.636 -19.281,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path168"
+         inkscape:connector-curvature="0" /><path
+         d="M 1239.55,612.863 H 1948.2"
+         style="fill:none;stroke:#000000;stroke-width:9.99975014;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path170"
+         inkscape:connector-curvature="0" /><path
+         d="m 1239.55,612.863 v 0"
+         style="fill:none;stroke:#000000;stroke-width:29.99920082;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path172"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,612.863 c 0,6.907 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.598 12.5,12.5"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path174"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,612.863 c 0,6.907 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.598 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path176"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,612.863 c 0,6.907 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.593 -12.5,-12.5 0,-6.902 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.598 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path178"
+         inkscape:connector-curvature="0" /><path
+         d="m 1490.87,666.363 v 34.731 c 0,10.652 8.63,19.285 19.29,19.285 h 25.71 c 10.65,0 19.28,-8.633 19.28,-19.285 v -34.731 c 0,-10.652 -8.63,-19.285 -19.28,-19.285 h -25.71 c -10.66,0 -19.29,8.633 -19.29,19.285"
+         style="fill:#6aa944;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path180"
+         inkscape:connector-curvature="0" /><path
+         d="m 1490.87,666.363 v 34.731 c 0,10.652 8.63,19.285 19.29,19.285 h 25.71 c 10.65,0 19.28,-8.633 19.28,-19.285 v -34.731 c 0,-10.652 -8.63,-19.285 -19.28,-19.285 h -25.71 c -10.66,0 -19.29,8.633 -19.29,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path182"
+         inkscape:connector-curvature="0" /><path
+         d="m 1593.88,683.73 h -28.35"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path184"
+         inkscape:connector-curvature="0" /><path
+         d="m 1622.22,683.73 -28.34,7.594 v -15.191 l 28.34,7.597"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path186"
+         inkscape:connector-curvature="0" /><path
+         d="m 1622.22,683.73 -28.34,7.594 v -15.191 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path188"
+         inkscape:connector-curvature="0" /><path
+         d="m 1632.6,666.363 v 34.731 c 0,10.652 8.63,19.285 19.28,19.285 h 25.71 c 10.66,0 19.29,-8.633 19.29,-19.285 v -34.731 c 0,-10.652 -8.63,-19.285 -19.29,-19.285 h -25.71 c -10.65,0 -19.28,8.633 -19.28,19.285"
+         style="fill:#4a907f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path190"
+         inkscape:connector-curvature="0" /><path
+         d="m 1632.6,666.363 v 34.731 c 0,10.652 8.63,19.285 19.28,19.285 h 25.71 c 10.66,0 19.29,-8.633 19.29,-19.285 v -34.731 c 0,-10.652 -8.63,-19.285 -19.29,-19.285 h -25.71 c -10.65,0 -19.28,8.633 -19.28,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path192"
+         inkscape:connector-curvature="0" /><path
+         d="M 1239.55,471.137 H 1948.2"
+         style="fill:none;stroke:#000000;stroke-width:9.99975014;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path194"
+         inkscape:connector-curvature="0" /><path
+         d="m 1239.55,471.137 v 0"
+         style="fill:none;stroke:#000000;stroke-width:29.99920082;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path196"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,471.137 c 0,6.902 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.598 -12.5,-12.5 0,-6.907 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.593 12.5,12.5"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path198"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,471.137 c 0,6.902 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.598 -12.5,-12.5 0,-6.907 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.593 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path200"
+         inkscape:connector-curvature="0" /><path
+         d="m 1960.7,471.137 c 0,6.902 -5.6,12.5 -12.5,12.5 -6.91,0 -12.5,-5.598 -12.5,-12.5 0,-6.907 5.59,-12.5 12.5,-12.5 6.9,0 12.5,5.593 12.5,12.5 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path202"
+         inkscape:connector-curvature="0" /><path
+         d="m 1490.87,524.633 v 34.734 c 0,10.649 8.63,19.285 19.29,19.285 h 25.71 c 10.65,0 19.28,-8.636 19.28,-19.285 v -34.734 c 0,-10.649 -8.63,-19.285 -19.28,-19.285 h -25.71 c -10.66,0 -19.29,8.636 -19.29,19.285"
+         style="fill:#b061d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path204"
+         inkscape:connector-curvature="0" /><path
+         d="m 1490.87,524.633 v 34.734 c 0,10.649 8.63,19.285 19.29,19.285 h 25.71 c 10.65,0 19.28,-8.636 19.28,-19.285 v -34.734 c 0,-10.649 -8.63,-19.285 -19.28,-19.285 h -25.71 c -10.66,0 -19.29,8.636 -19.29,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path206"
+         inkscape:connector-curvature="0" /><path
+         d="m 1593.88,542 h -28.35"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path208"
+         inkscape:connector-curvature="0" /><path
+         d="m 1622.22,542 -28.34,7.594 v -15.188 l 28.34,7.594"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path210"
+         inkscape:connector-curvature="0" /><path
+         d="m 1622.22,542 -28.34,7.594 v -15.188 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path212"
+         inkscape:connector-curvature="0" /><path
+         d="m 1632.6,524.633 v 34.734 c 0,10.649 8.63,19.285 19.28,19.285 h 25.71 c 10.66,0 19.29,-8.636 19.29,-19.285 v -34.734 c 0,-10.649 -8.63,-19.285 -19.29,-19.285 h -25.71 c -10.65,0 -19.28,8.636 -19.28,19.285"
+         style="fill:#6f84bd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path214"
+         inkscape:connector-curvature="0" /><path
+         d="m 1632.6,524.633 v 34.734 c 0,10.649 8.63,19.285 19.28,19.285 h 25.71 c 10.66,0 19.29,-8.636 19.29,-19.285 v -34.734 c 0,-10.649 -8.63,-19.285 -19.29,-19.285 h -25.71 c -10.65,0 -19.28,8.636 -19.28,19.285 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path216"
+         inkscape:connector-curvature="0" /><path
+         d="m 902.379,1511.44 -88.578,-212.6"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path218"
+         inkscape:connector-curvature="0" /><path
+         d="m 902.379,1511.44 88.582,-212.6"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path220"
+         inkscape:connector-curvature="0" /><path
+         d="M 769.508,1724.03 636.641,1298.84"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path222"
+         inkscape:connector-curvature="0" /><path
+         d="M 769.508,1724.03 902.379,1511.44"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path224"
+         inkscape:connector-curvature="0" /><path
+         d="m 604.5,1281.48 v 34.73 c 0,10.65 8.633,19.29 19.281,19.29 h 25.715 c 10.649,0 19.281,-8.64 19.281,-19.29 v -34.73 c 0,-10.65 -8.632,-19.29 -19.281,-19.29 h -25.715 c -10.648,0 -19.281,8.64 -19.281,19.29"
+         style="fill:#6aa944;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path226"
+         inkscape:connector-curvature="0" /><path
+         d="m 604.5,1281.48 v 34.73 c 0,10.65 8.633,19.29 19.281,19.29 h 25.715 c 10.649,0 19.281,-8.64 19.281,-19.29 v -34.73 c 0,-10.65 -8.632,-19.29 -19.281,-19.29 h -25.715 c -10.648,0 -19.281,8.64 -19.281,19.29 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path228"
+         inkscape:connector-curvature="0" /><path
+         d="m 781.66,1281.48 v 34.73 c 0,10.65 8.633,19.29 19.285,19.29 h 25.711 c 10.649,0 19.285,-8.64 19.285,-19.29 v -34.73 c 0,-10.65 -8.636,-19.29 -19.285,-19.29 h -25.711 c -10.652,0 -19.285,8.64 -19.285,19.29"
+         style="fill:#c54c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path230"
+         inkscape:connector-curvature="0" /><path
+         d="m 781.66,1281.48 v 34.73 c 0,10.65 8.633,19.29 19.285,19.29 h 25.711 c 10.649,0 19.285,-8.64 19.285,-19.29 v -34.73 c 0,-10.65 -8.636,-19.29 -19.285,-19.29 h -25.711 c -10.652,0 -19.285,8.64 -19.285,19.29 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path232"
+         inkscape:connector-curvature="0" /><path
+         d="m 958.82,1281.48 v 34.73 c 0,10.65 8.633,19.29 19.285,19.29 h 25.715 c 10.65,0 19.28,-8.64 19.28,-19.29 v -34.73 c 0,-10.65 -8.63,-19.29 -19.28,-19.29 h -25.715 c -10.652,0 -19.285,8.64 -19.285,19.29"
+         style="fill:#b061d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path234"
+         inkscape:connector-curvature="0" /><path
+         d="m 958.82,1281.48 v 34.73 c 0,10.65 8.633,19.29 19.285,19.29 h 25.715 c 10.65,0 19.28,-8.64 19.28,-19.29 v -34.73 c 0,-10.65 -8.63,-19.29 -19.28,-19.29 h -25.715 c -10.652,0 -19.285,8.64 -19.285,19.29 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path236"
+         inkscape:connector-curvature="0" /><path
+         d="m 870.238,1494.07 v 34.73 c 0,10.65 8.637,19.29 19.285,19.29 h 25.711 c 10.653,0 19.286,-8.64 19.286,-19.29 v -34.73 c 0,-10.65 -8.633,-19.28 -19.286,-19.28 h -25.711 c -10.648,0 -19.285,8.63 -19.285,19.28"
+         style="fill:#4a907f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path238"
+         inkscape:connector-curvature="0" /><path
+         d="m 870.238,1494.07 v 34.73 c 0,10.65 8.637,19.29 19.285,19.29 h 25.711 c 10.653,0 19.286,-8.64 19.286,-19.29 v -34.73 c 0,-10.65 -8.633,-19.28 -19.286,-19.28 h -25.711 c -10.648,0 -19.285,8.63 -19.285,19.28 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path240"
+         inkscape:connector-curvature="0" /><path
+         d="m 737.371,1706.66 v 34.73 c 0,10.66 8.633,19.29 19.281,19.29 h 25.715 c 10.649,0 19.281,-8.63 19.281,-19.29 v -34.73 c 0,-10.65 -8.632,-19.28 -19.281,-19.28 h -25.715 c -10.648,0 -19.281,8.63 -19.281,19.28"
+         style="fill:#6f84bd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path242"
+         inkscape:connector-curvature="0" /><path
+         d="m 737.371,1706.66 v 34.73 c 0,10.66 8.633,19.29 19.281,19.29 h 25.715 c 10.649,0 19.281,-8.63 19.281,-19.29 v -34.73 c 0,-10.65 -8.632,-19.28 -19.281,-19.28 h -25.715 c -10.648,0 -19.281,8.63 -19.281,19.28 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path244"
+         inkscape:connector-curvature="0" /><path
+         d="m 713.703,1493.03 10.629,18.41 -10.629,18.41 h -21.258 l -10.629,-18.41 10.629,-18.41 h 21.258"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path246"
+         inkscape:connector-curvature="0" /><path
+         d="m 713.703,1493.03 10.629,18.41 -10.629,18.41 h -21.258 l -10.629,-18.41 10.629,-18.41 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path248"
+         inkscape:connector-curvature="0" /><path
+         d="m 1753.32,1511.44 -88.58,-212.6"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path250"
+         inkscape:connector-curvature="0" /><path
+         d="m 1753.32,1511.44 88.58,-212.6"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path252"
+         inkscape:connector-curvature="0" /><path
+         d="M 1620.45,1724.03 1487.58,1298.84"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path254"
+         inkscape:connector-curvature="0" /><path
+         d="m 1620.45,1724.03 132.87,-212.59"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path256"
+         inkscape:connector-curvature="0" /><path
+         d="m 1455.44,1281.48 v 34.73 c 0,10.65 8.63,19.29 19.28,19.29 h 25.71 c 10.66,0 19.29,-8.64 19.29,-19.29 v -34.73 c 0,-10.65 -8.63,-19.29 -19.29,-19.29 h -25.71 c -10.65,0 -19.28,8.64 -19.28,19.29"
+         style="fill:#b061d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path258"
+         inkscape:connector-curvature="0" /><path
+         d="m 1455.44,1281.48 v 34.73 c 0,10.65 8.63,19.29 19.28,19.29 h 25.71 c 10.66,0 19.29,-8.64 19.29,-19.29 v -34.73 c 0,-10.65 -8.63,-19.29 -19.29,-19.29 h -25.71 c -10.65,0 -19.28,8.64 -19.28,19.29 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path260"
+         inkscape:connector-curvature="0" /><path
+         d="m 1632.6,1281.48 v 34.73 c 0,10.65 8.63,19.29 19.28,19.29 h 25.71 c 10.66,0 19.29,-8.64 19.29,-19.29 v -34.73 c 0,-10.65 -8.63,-19.29 -19.29,-19.29 h -25.71 c -10.65,0 -19.28,8.64 -19.28,19.29"
+         style="fill:#c54c3c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path262"
+         inkscape:connector-curvature="0" /><path
+         d="m 1632.6,1281.48 v 34.73 c 0,10.65 8.63,19.29 19.28,19.29 h 25.71 c 10.66,0 19.29,-8.64 19.29,-19.29 v -34.73 c 0,-10.65 -8.63,-19.29 -19.29,-19.29 h -25.71 c -10.65,0 -19.28,8.64 -19.28,19.29 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path264"
+         inkscape:connector-curvature="0" /><path
+         d="m 1809.76,1281.48 v 34.73 c 0,10.65 8.63,19.29 19.28,19.29 h 25.72 c 10.65,0 19.28,-8.64 19.28,-19.29 v -34.73 c 0,-10.65 -8.63,-19.29 -19.28,-19.29 h -25.72 c -10.65,0 -19.28,8.64 -19.28,19.29"
+         style="fill:#6aa944;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path266"
+         inkscape:connector-curvature="0" /><path
+         d="m 1809.76,1281.48 v 34.73 c 0,10.65 8.63,19.29 19.28,19.29 h 25.72 c 10.65,0 19.28,-8.64 19.28,-19.29 v -34.73 c 0,-10.65 -8.63,-19.29 -19.28,-19.29 h -25.72 c -10.65,0 -19.28,8.64 -19.28,19.29 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path268"
+         inkscape:connector-curvature="0" /><path
+         d="m 1721.18,1494.07 v 34.73 c 0,10.65 8.63,19.29 19.28,19.29 h 25.72 c 10.65,0 19.28,-8.64 19.28,-19.29 v -34.73 c 0,-10.65 -8.63,-19.28 -19.28,-19.28 h -25.72 c -10.65,0 -19.28,8.63 -19.28,19.28"
+         style="fill:#4a907f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path270"
+         inkscape:connector-curvature="0" /><path
+         d="m 1721.18,1494.07 v 34.73 c 0,10.65 8.63,19.29 19.28,19.29 h 25.72 c 10.65,0 19.28,-8.64 19.28,-19.29 v -34.73 c 0,-10.65 -8.63,-19.28 -19.28,-19.28 h -25.72 c -10.65,0 -19.28,8.63 -19.28,19.28 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path272"
+         inkscape:connector-curvature="0" /><path
+         d="m 1588.31,1706.66 v 34.73 c 0,10.66 8.63,19.29 19.28,19.29 h 25.71 c 10.66,0 19.29,-8.63 19.29,-19.29 v -34.73 c 0,-10.65 -8.63,-19.28 -19.29,-19.28 h -25.71 c -10.65,0 -19.28,8.63 -19.28,19.28"
+         style="fill:#6f84bd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path274"
+         inkscape:connector-curvature="0" /><path
+         d="m 1588.31,1706.66 v 34.73 c 0,10.66 8.63,19.29 19.28,19.29 h 25.71 c 10.66,0 19.29,-8.63 19.29,-19.29 v -34.73 c 0,-10.65 -8.63,-19.28 -19.29,-19.28 h -25.71 c -10.65,0 -19.28,8.63 -19.28,19.28 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path276"
+         inkscape:connector-curvature="0" /><path
+         d="m 1697.52,1599.32 10.62,18.41 -10.62,18.41 h -21.27 l -10.63,-18.41 10.63,-18.41 h 21.27"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path278"
+         inkscape:connector-curvature="0" /><path
+         d="m 1697.52,1599.32 10.62,18.41 -10.62,18.41 h -21.27 l -10.63,-18.41 10.63,-18.41 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path280"
+         inkscape:connector-curvature="0" /><path
+         d="m 1719.66,1386.73 10.63,18.41 -10.63,18.41 h -21.26 l -10.63,-18.41 10.63,-18.41 h 21.26"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path282"
+         inkscape:connector-curvature="0" /><path
+         d="m 1719.66,1386.73 10.63,18.41 -10.63,18.41 h -21.26 l -10.63,-18.41 10.63,-18.41 z"
+         style="fill:none;stroke:#000000;stroke-width:4.99986982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         id="path284"
+         inkscape:connector-curvature="0" /><g
+         id="g286"
+         transform="scale(10)"><text
+   transform="matrix(1,0,0,-1,40.6801,181.68)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMBX8;-inkscape-font-specification:CMBX8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text296"><tspan
+     x="0 5.9999976 10.079995 14.519996 22.199993 26.039993 30.959986 36.599987 41.519985 44.27998 49.199978 54.119976 56.879974 61.319969 68.159973 72.959976 78.35997 86.999809 94.919731 100.31973 104.15973 108.95973 112.79972 115.55972 120.47972 125.87971 182.63965 190.19966 195.35956 200.75957 205.19954 274.79941 281.15939 286.55939 291.4794 295.91937 373.1994 378.5994 381.35944 385.19943 389.6394"
+     y="0"
+     sodipodi:role="line"
+     id="tspan288">TreetopologiesandmutationsNodesEdgesSites</tspan><tspan
+     x="349.56 358.79999 364.19998 368.04001 372.84 376.68005 379.44003 384.36008 389.76007"
+     y="70.919899"
+     sodipodi:role="line"
+     id="tspan290">Mutations</tspan><tspan
+     x="0 3.599998 8.7601538 12.600155 17.040148 21.120144 25.680065 30.480062 33.240059"
+     y="85.080101"
+     sodipodi:role="line"
+     id="tspan292">Intervals</tspan><tspan
+     x="287.76001 294.12 299.51999 303.84 308.99982 314.39981 318.83981 327.59979 333.59982 337.67981 342.11978 349.91971 355.3197 359.75967 364.91971 370.3197 374.75967 380.15967 384.47971"
+     y="-19.319901"
+     sodipodi:role="line"
+     id="tspan294">EncodedTreeSequence</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,91.5601,2.6399)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text310"><tspan
+     x="0 6.5999966 10.319994 14.999995 19.199995 26.279984 28.679981 35.399986 40.319904 44.519905 47.879902 50.2799 53.519909 55.919907 60.119904"
+     y="0"
+     sodipodi:role="line"
+     id="tspan298">Genomicposition</tspan><tspan
+     x="-40.5602 30.239801 98.999931 103.19994"
+     y="-5.7597699"
+     sodipodi:role="line"
+     id="tspan300">0510</tspan><tspan
+     x="-13.5602 -8.8802042 -6.480206 -3.2402048 3.3597078 57.239803 61.919804 64.319801 67.559799 74.159729"
+     y="-21.35977"
+     sodipodi:role="line"
+     id="tspan302">Site0Site1</tspan><tspan
+     x="-74.880096"
+     y="-126.95977"
+     id="tspan304">0</tspan><tspan
+     x="-74.880096"
+     y="-145.31998"
+     id="tspan306">1</tspan><tspan
+     x="-74.880096"
+     y="-163.80006"
+     id="tspan308">2</tspan></text>
+
+
+
+<text
+   transform="matrix(0,1,1,0,6.6,113.52)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text314"><tspan
+     x="0 6.1199956 8.5199938 15.599994 22.199995 27.119913 30.839911 33.479916 37.679916 41.039917 47.519928 52.199928 55.559933 59.27993 62.639923 66.359932 70.800003"
+     y="0"
+     sodipodi:role="line"
+     id="tspan312">Timebeforepresent</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,114.72,94.2)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text350"><tspan
+     x="0 14.280046"
+     y="0"
+     sodipodi:role="line"
+     id="tspan316">13</tspan><tspan
+     x="0 14.280046"
+     y="14.2801"
+     sodipodi:role="line"
+     id="tspan318">34</tspan><tspan
+     x="-35.400002 -21.239824"
+     y="28.439899"
+     sodipodi:role="line"
+     id="tspan320">03</tspan><tspan
+     x="-35.400002 -21.239824"
+     y="42.600101"
+     sodipodi:role="line"
+     id="tspan322">24</tspan><tspan
+     x="35.519901 49.680077"
+     y="28.439899"
+     sodipodi:role="line"
+     id="tspan324">23</tspan><tspan
+     x="35.519901 49.680077"
+     y="42.600101"
+     sodipodi:role="line"
+     id="tspan326">04</tspan><tspan
+     x="-53.159801 -35.399685 -17.75984"
+     y="-33.119801"
+     sodipodi:role="line"
+     id="tspan328">210</tspan><tspan
+     x="-26.6399"
+     y="-54.360001"
+     id="tspan330">3</tspan><tspan
+     x="-39.839901"
+     y="-75.5998"
+     id="tspan332">4</tspan><tspan
+     x="-54.119999 -36.480156 -18.840307"
+     y="-18.84"
+     sodipodi:role="line"
+     id="tspan334">TAA</tspan><tspan
+     x="-51.00008"
+     y="-54.359901"
+     id="tspan336">0</tspan><tspan
+     x="31.919821 49.679935 67.319778"
+     y="-33.119701"
+     sodipodi:role="line"
+     id="tspan338">012</tspan><tspan
+     x="58.56002"
+     y="-54.359901"
+     id="tspan340">3</tspan><tspan
+     x="45.24012"
+     y="-75.599701"
+     id="tspan342">4</tspan><tspan
+     x="30.71982 48.719833 66.119858"
+     y="-18.839899"
+     sodipodi:role="line"
+     id="tspan344">GCG</tspan><tspan
+     x="56.399921"
+     y="-65.039902"
+     id="tspan346">1</tspan><tspan
+     x="49.560081"
+     y="-43.799702"
+     id="tspan348">2</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,219.11988,168.8399)"
+   style="font-variant:normal;font-weight:normal;font-size:5.97758007px;font-family:CMR6;-inkscape-font-specification:CMR6;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text364"><tspan
+     x="0 2.6399908 22.680067 27.840082 30.000078 36.000069"
+     y="0"
+     sodipodi:role="line"
+     id="tspan352">IDTime</tspan><tspan
+     x="54.2402 58.800205 62.040184 64.32019 78.840157 84.120163 86.280159 89.880165 93.720261 105.84016 111.00018 115.08016 117.24018 119.4002"
+     y="0.120313"
+     sodipodi:role="line"
+     id="tspan354">LeftRightChild</tspan><tspan
+     x="130.91991 135.59996 139.19997 142.07997 145.31995 149.16011 170.0401 172.6801 189.47997 194.16005 197.76006 200.64005 202.80003 205.68008 207.84003 211.44003"
+     y="0"
+     sodipodi:role="line"
+     id="tspan356">ParentIDPosition</tspan><tspan
+     x="224.1601 229.5601 233.64009 236.88011 240.1201 243.00008 245.88013 248.76012 252.36012"
+     y="0.120313"
+     sodipodi:role="line"
+     id="tspan358">Ancestral</tspan><tspan
+     x="170.04021 172.68019 196.32027 200.40025 202.56024 205.44029"
+     y="70.920311"
+     sodipodi:role="line"
+     id="tspan360">IDSite</tspan><tspan
+     x="222.60001 228 231.83986 235.91983 246.83986 252.35988 255.59987 258.47986 260.63986 264.23984 267.47983"
+     y="71.040237"
+     sodipodi:role="line"
+     id="tspan362">NodeDerived</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,277.79988,157.91957)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text380"><tspan
+     x="0 24.719934 28.919933 53.759739 80.759758"
+     y="0"
+     sodipodi:role="line"
+     id="tspan366">01013</tspan><tspan
+     x="0 24.719934 28.919933 53.759739 80.759758"
+     y="14.1602"
+     sodipodi:role="line"
+     id="tspan368">01034</tspan><tspan
+     x="0 26.880074 53.760147 80.76017"
+     y="28.3204"
+     sodipodi:role="line"
+     id="tspan370">0503</tspan><tspan
+     x="0 26.880074 53.760147 80.76017"
+     y="42.480598"
+     sodipodi:role="line"
+     id="tspan372">0524</tspan><tspan
+     x="0 24.719934 28.919933 53.759739 80.759758"
+     y="56.6408"
+     sodipodi:role="line"
+     id="tspan374">51023</tspan><tspan
+     x="0 24.719934 28.919933 53.759739 80.759758"
+     y="70.801003"
+     sodipodi:role="line"
+     id="tspan376">51004</tspan><tspan
+     x="-56.760201 -33.120377"
+     y="0.001"
+     sodipodi:role="line"
+     id="tspan378">00</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,248.87948,157.91857)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMMI8;-inkscape-font-specification:CMMI8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text384"><tspan
+     x="0"
+     y="0"
+     id="tspan382">.</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,251.27948,157.91857)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text390"><tspan
+     x="0"
+     y="0"
+     id="tspan386">0</tspan><tspan
+     x="-30.239799 -6.5999756"
+     y="14.1598"
+     sodipodi:role="line"
+     id="tspan388">10</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,248.87948,143.75877)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMMI8;-inkscape-font-specification:CMMI8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text394"><tspan
+     x="0"
+     y="0"
+     id="tspan392">.</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,251.27948,143.75877)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text400"><tspan
+     x="0"
+     y="0"
+     id="tspan396">0</tspan><tspan
+     x="-30.239799 -6.5999756"
+     y="14.1602"
+     sodipodi:role="line"
+     id="tspan398">20</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,248.87948,129.59856)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMMI8;-inkscape-font-specification:CMMI8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text404"><tspan
+     x="0"
+     y="0"
+     id="tspan402">.</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,251.27948,129.59856)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text410"><tspan
+     x="0"
+     y="0"
+     id="tspan406">0</tspan><tspan
+     x="-30.239799 -6.5999756"
+     y="14.1598"
+     sodipodi:role="line"
+     id="tspan408">31</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,248.87948,115.43877)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMMI8;-inkscape-font-specification:CMMI8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text414"><tspan
+     x="0"
+     y="0"
+     id="tspan412">.</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,251.27948,115.43877)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text420"><tspan
+     x="0"
+     y="0"
+     id="tspan416">0</tspan><tspan
+     x="-30.239799 -6.5999756"
+     y="14.1602"
+     sodipodi:role="line"
+     id="tspan418">42</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,248.87948,101.27857)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMMI8;-inkscape-font-specification:CMMI8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text424"><tspan
+     x="0"
+     y="0"
+     id="tspan422">.</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,251.27948,101.27857)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text430"><tspan
+     x="0"
+     y="0"
+     id="tspan426">0</tspan><tspan
+     x="139.92 164.88016"
+     y="-56.639801"
+     sodipodi:role="line"
+     id="tspan428">02</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,420.35968,157.91837)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMMI8;-inkscape-font-specification:CMMI8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text434"><tspan
+     x="0"
+     y="0"
+     id="tspan432">.</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,422.75968,157.91837)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text442"><tspan
+     x="0"
+     y="0"
+     id="tspan436">5</tspan><tspan
+     x="32.519901"
+     y="0.119922"
+     id="tspan438">A</tspan><tspan
+     x="-31.5602 -6.6000471"
+     y="14.159722"
+     sodipodi:role="line"
+     id="tspan440">17</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,420.35968,143.75864)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMMI8;-inkscape-font-specification:CMMI8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text446"><tspan
+     x="0"
+     y="0"
+     id="tspan444">.</tspan></text>
+
+
+
+<text
+   transform="matrix(1,0,0,-1,422.75968,143.75864)"
+   style="font-variant:normal;font-weight:normal;font-size:7.97010994px;font-family:CMR8;-inkscape-font-specification:CMR8;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   id="text464"><tspan
+     x="0"
+     y="0"
+     id="tspan448">5</tspan><tspan
+     x="32.400002"
+     y="0.119922"
+     id="tspan450">G</tspan><tspan
+     x="-31.5602 -3.2402472 25.079706"
+     y="56.640221"
+     sodipodi:role="line"
+     id="tspan452">002</tspan><tspan
+     x="52.4398"
+     y="56.880066"
+     id="tspan454">T</tspan><tspan
+     x="-31.5602 -3.2402472 25.079706"
+     y="70.919868"
+     sodipodi:role="line"
+     id="tspan456">113</tspan><tspan
+     x="52.4398"
+     y="71.040176"
+     id="tspan458">C</tspan><tspan
+     x="-31.5602 -3.2402472 25.079706"
+     y="85.079979"
+     sodipodi:role="line"
+     id="tspan460">211</tspan><tspan
+     x="52.200001"
+     y="85.199898"
+     id="tspan462">G</tspan></text>
+
+
+
+</g></g></g><g
+     inkscape:groupmode="layer"
+     id="layer7"
+     inkscape:label="borders"
+     transform="translate(-23.346868,-5.8920064)"
+     style="display:inline"><rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect13625"
+       width="516.27667"
+       height="270.48798"
+       x="24.096928"
+       y="6.3920064" /><path
+       inkscape:connector-curvature="0"
+       id="path13642"
+       d="M 419.93404,6.392006 V 276.27758"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1"
+       sodipodi:nodetypes="cc" /><path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 540.42501,131.33479 H 419.85944 m 0,42 H 277.907 m 0,-52 H 23.346868"
+       id="path13644"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" /><path
+       sodipodi:nodetypes="cc"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 278.53646,6.392006 V 276.27758"
+       id="path2500"
+       inkscape:connector-curvature="0" /></g><g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="scale_axes"
+     style="display:inline"
+     transform="translate(-23.346868,-5.8920064)"><path
+   style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker10146);marker-mid:url(#marker10390);marker-end:url(#marker10390)"
+   d="m 57.93294,221.21106 v -27.81843 -30.90921 -24.9092"
+   id="path10136"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="cccc" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:tb-rl;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="-35.546001"
+   y="-203.01596"
+   id="text10134"
+   transform="scale(-1)"><tspan
+     sodipodi:role="line"
+     id="tspan10132"
+     x="-203.01596"
+     y="-35.546001"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:tb-rl;text-anchor:start;stroke-width:0.81213886px">Time ago</tspan></text>
+
+
+
+<text
+   id="text10688"
+   y="165.94304"
+   x="43.124779"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     sodipodi:role="line"
+     id="tspan10690"
+     x="43.124779"
+     y="165.94304">2</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="43.124779"
+   y="195.94304"
+   id="text10694"><tspan
+     y="195.94304"
+     x="43.124779"
+     id="tspan10692"
+     sodipodi:role="line">1</tspan></text>
+
+
+
+<text
+   id="text10698"
+   y="223.94304"
+   x="43.124779"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     sodipodi:role="line"
+     id="tspan10696"
+     x="43.124779"
+     y="223.94304">0</tspan></text>
+
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="43.124779"
+   y="141.94304"
+   id="text2607"><tspan
+     y="141.94304"
+     x="43.124779"
+     id="tspan2605"
+     sodipodi:role="line">3</tspan></text>
+
+
+</g><g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="tables"
+     style="display:inline;opacity:1"
+     transform="translate(-23.346868,-5.8920064)"><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="297.12842"
+   y="134.22552"
+   id="text4276"><tspan
+     sodipodi:role="line"
+     id="tspan4278"
+     x="297.12842"
+     y="136.75711"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px" /></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="431.01755"
+   y="19.391365"
+   id="text4224"><tspan
+     sodipodi:role="line"
+     id="tspan4228"
+     x="431.01755"
+     y="19.391365"
+     style="font-size:12.18208313px;line-height:1.25;stroke-width:0.81213886px">Nodes:</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="442.49545"
+   y="32.260189"
+   id="text4234"><tspan
+     sodipodi:role="line"
+     id="tspan4238"
+     x="442.49545"
+     y="32.260189"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">ID</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="472.98102"
+   y="32.260189"
+   id="text4244"><tspan
+     y="32.260189"
+     x="472.98102"
+     sodipodi:role="line"
+     id="tspan4246"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">time</tspan></text>
+
+<text
+   id="text4256"
+   y="45.25441"
+   x="444.99255"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="45.25441"
+     x="444.99255"
+     id="tspan4258"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="444.99255"
+   y="58.248619"
+   id="text4260"><tspan
+     sodipodi:role="line"
+     id="tspan4262"
+     x="444.99255"
+     y="58.248619"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">1</tspan></text>
+
+<text
+   id="text4264"
+   y="71.242859"
+   x="444.99255"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.242859"
+     x="444.99255"
+     id="tspan4266"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">2</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="444.99255"
+   y="98.237083"
+   id="text4268"><tspan
+     sodipodi:role="line"
+     id="tspan4270"
+     x="444.99255"
+     y="98.237083"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">4</tspan></text>
+
+<text
+   id="text4272"
+   y="111.23129"
+   x="444.99255"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.23129"
+     x="444.99255"
+     id="tspan4274"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">5</tspan><tspan
+     id="tspan2781"
+     y="123.92096"
+     x="444.99255"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">6</tspan></text>
+
+<text
+   id="text4288"
+   y="45.25441"
+   x="477.47815"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan4290"
+     sodipodi:role="line"
+     x="477.47815"
+     y="45.25441"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0.0</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="477.47815"
+   y="58.248619"
+   id="text4314"><tspan
+     y="58.248619"
+     x="477.47815"
+     sodipodi:role="line"
+     id="tspan4316"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0.0</tspan></text>
+
+<text
+   id="text4318"
+   y="98.237083"
+   x="477.47815"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan4320"
+     sodipodi:role="line"
+     x="477.47815"
+     y="98.237083"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">2.0</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="477.47815"
+   y="111.23129"
+   id="text4322"><tspan
+     id="tspan2775"
+     y="111.23129"
+     x="477.47815"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">3.0</tspan><tspan
+     id="tspan2779"
+     y="123.92096"
+     x="477.47815"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">1.0</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="463.83044"
+   y="99.620216"
+   id="text4338"><tspan
+     sodipodi:role="line"
+     id="tspan4340"
+     x="463.83044"
+     y="99.620216"
+     style="font-size:16.24277687px;line-height:1.25;stroke-width:0.81213886px"> </tspan></text>
+
+<text
+   id="text4920"
+   y="71.242859"
+   x="477.47815"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan4922"
+     sodipodi:role="line"
+     x="477.47815"
+     y="71.242859"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0.0</tspan></text>
+
+<text
+   id="text4342"
+   y="20.37925"
+   x="285.83728"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan4344"
+     sodipodi:role="line"
+     x="285.83728"
+     y="20.37925"
+     style="font-size:12.18208313px;line-height:1.25;stroke-width:0.81213886px">Edges:</tspan></text>
+
+
+
+<text
+   id="text4346"
+   y="39.248074"
+   x="286.56381"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="39.248074"
+     x="286.56381"
+     id="tspan4348"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">left</tspan></text>
+
+
+
+<text
+   id="text4350"
+   y="39.248074"
+   x="319.04935"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan4352"
+     sodipodi:role="line"
+     x="319.04935"
+     y="39.248074"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">right</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="290.56381"
+   y="52.242294"
+   id="text4354"><tspan
+     sodipodi:role="line"
+     id="tspan4356"
+     x="290.56381"
+     y="52.242294"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0</tspan></text>
+
+
+
+<text
+   id="text4358"
+   y="78.927986"
+   x="290.56381"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="78.927986"
+     x="290.56381"
+     id="tspan4360"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0</tspan></text>
+
+
+
+
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="323.04935"
+   y="52.242294"
+   id="text4382"><tspan
+     y="52.242294"
+     x="323.04935"
+     sodipodi:role="line"
+     id="tspan4384"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">20</tspan></text>
+
+
+
+<text
+   id="text4386"
+   y="78.927986"
+   x="323.04935"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan4388"
+     sodipodi:role="line"
+     x="323.04935"
+     y="78.927986"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">10</tspan></text>
+
+
+
+
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="351.53491"
+   y="39.248074"
+   id="text4410"><tspan
+     sodipodi:role="line"
+     id="tspan4412"
+     x="351.53491"
+     y="39.248074"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">parent</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="392.51752"
+   y="39.248074"
+   id="text4414"><tspan
+     y="39.248074"
+     x="392.51752"
+     sodipodi:role="line"
+     id="tspan4416"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">child </tspan></text>
+
+
+
+<text
+   id="text4418"
+   y="52.242294"
+   x="399.28058"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="52.242294"
+     x="399.28058"
+     id="tspan4420"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="399.28058"
+   y="78.999855"
+   id="text4422"><tspan
+     sodipodi:role="line"
+     id="tspan4424"
+     x="399.28058"
+     y="78.999855"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">2</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="399.28058"
+   y="118.95653"
+   id="text4430"><tspan
+     sodipodi:role="line"
+     id="tspan4432"
+     x="399.28058"
+     y="118.95653"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">6</tspan></text>
+
+
+
+<text
+   id="text4434"
+   y="158.98508"
+   x="399.28058"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="158.98508"
+     x="399.28058"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2797">6</tspan></text>
+
+
+
+<text
+   id="text4446"
+   y="52.242294"
+   x="358.63892"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan4448"
+     sodipodi:role="line"
+     x="358.63892"
+     y="52.242294"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">4</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="358.63892"
+   y="78.929237"
+   id="text4450"><tspan
+     y="78.929237"
+     x="358.63892"
+     sodipodi:role="line"
+     id="tspan4452"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">4</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="358.63892"
+   y="118.95964"
+   id="text4458"><tspan
+     y="118.95964"
+     x="358.63892"
+     sodipodi:role="line"
+     id="tspan4460"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">4</tspan></text>
+
+
+
+<text
+   id="text4462"
+   y="158.99004"
+   x="358.63892"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     sodipodi:role="line"
+     x="358.63892"
+     y="158.99004"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2795">4</tspan></text>
+
+
+
+<text
+   id="text4623"
+   y="105.61369"
+   x="290.56381"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="105.61369"
+     x="290.56381"
+     id="tspan4625"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0</tspan></text>
+
+
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="399.28058"
+   y="105.61864"
+   id="text4631"><tspan
+     sodipodi:role="line"
+     id="tspan4633"
+     x="399.28058"
+     y="105.61864"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">4</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="358.63892"
+   y="105.54429"
+   id="text4635"><tspan
+     y="105.54429"
+     x="358.63892"
+     sodipodi:role="line"
+     id="tspan4637"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">5</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="290.56381"
+   y="92.270851"
+   id="text4924"><tspan
+     sodipodi:role="line"
+     id="tspan4926"
+     x="290.56381"
+     y="92.270851"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0</tspan></text>
+
+
+
+
+
+<text
+   id="text4932"
+   y="92.270851"
+   x="399.28058"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="92.270851"
+     x="399.28058"
+     id="tspan4934"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">3</tspan></text>
+
+
+
+<text
+   id="text4936"
+   y="92.200821"
+   x="358.63892"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan4938"
+     sodipodi:role="line"
+     x="358.63892"
+     y="92.200821"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">5</tspan></text>
+
+
+
+<text
+   id="text12897"
+   y="56.260189"
+   x="585.94348"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="58.791779"
+     x="585.94348"
+     id="tspan12895"
+     sodipodi:role="line" /></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="427.15656"
+   y="143.3705"
+   id="text12853"><tspan
+     style="font-size:12.18208313px;line-height:1.25;stroke-width:0.81213886px"
+     y="143.3705"
+     x="427.15656"
+     sodipodi:role="line"
+     id="tspan12851">Sites:</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="450.36859"
+   y="158.23932"
+   id="text12861"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="158.23932"
+     x="450.36859"
+     sodipodi:role="line"
+     id="tspan12859">position</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="433.88312"
+   y="158.23932"
+   id="text12857"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     id="tspan12855"
+     x="433.88312"
+     y="158.23932">ID</tspan></text>
+
+<text
+   id="text12901"
+   y="145.03448"
+   x="513.06738"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;text-align:center;text-anchor:middle;stroke-width:0.81213886px"
+     id="tspan12899"
+     sodipodi:role="line"
+     x="514.68335"
+     y="145.03448">ancestral </tspan><tspan
+     style="font-size:10.15173626px;line-height:1.25;text-align:center;text-anchor:middle;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     x="513.06738"
+     y="157.72415"
+     id="tspan622">state</tspan></text>
+
+
+
+
+
+
+
+<text
+   id="text12969"
+   y="210.64677"
+   x="282.87436"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="210.64677"
+     x="282.87436"
+     id="tspan12967"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">ID</tspan></text>
+
+<text
+   id="text12973"
+   y="210.64677"
+   x="313.35983"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan12971"
+     sodipodi:role="line"
+     x="313.35983"
+     y="210.64677"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">site</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="344.82809"
+   y="210.64677"
+   id="text12993"><tspan
+     y="210.64677"
+     x="344.82809"
+     sodipodi:role="line"
+     id="tspan12991"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">node</tspan></text>
+
+<text
+   id="text13005"
+   y="193.77795"
+   x="282.1478"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan13003"
+     sodipodi:role="line"
+     x="282.1478"
+     y="193.77795"
+     style="font-size:12.18208313px;line-height:1.25;stroke-width:0.81213886px">Mutations:</tspan></text>
+
+<text
+   id="text13009"
+   y="196.83952"
+   x="397.28516"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;text-align:center;text-anchor:middle;stroke-width:0.81213886px"
+     id="tspan13007"
+     sodipodi:role="line"
+     x="397.28516"
+     y="196.83952">derived</tspan><tspan
+     style="font-size:10.15173626px;line-height:1.25;text-align:center;text-anchor:middle;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     x="397.28516"
+     y="209.52919"
+     id="tspan684">state</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="284.87436"
+   y="225.64099"
+   id="text12977"><tspan
+     sodipodi:role="line"
+     id="tspan12975"
+     x="284.87436"
+     y="225.64099"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">0</tspan></text>
+
+<text
+   id="text12981"
+   y="238.63521"
+   x="284.87436"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="238.63521"
+     x="284.87436"
+     id="tspan12979"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">1</tspan><tspan
+     y="244.87456"
+     x="284.87436"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2861" /></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="317.35983"
+   y="225.64099"
+   id="text12985"><tspan
+     y="225.64099"
+     x="317.35983"
+     sodipodi:role="line"
+     id="tspan12983"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">1</tspan></text>
+
+<text
+   id="text12989"
+   y="238.63521"
+   x="317.35983"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan12987"
+     sodipodi:role="line"
+     x="317.35983"
+     y="238.63521"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">2</tspan></text>
+
+<text
+   id="text12997"
+   y="225.64099"
+   x="352.94946"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan12995"
+     sodipodi:role="line"
+     x="352.94946"
+     y="225.64099"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">3</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="352.94946"
+   y="238.63521"
+   id="text13001"><tspan
+     y="238.63521"
+     x="352.94946"
+     sodipodi:role="line"
+     id="tspan12999"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">2</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="392.94946"
+   y="225.64099"
+   id="text13013"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="225.64099"
+     x="392.94946"
+     sodipodi:role="line"
+     id="tspan13011">T</tspan></text>
+
+<text
+   id="text13017"
+   y="238.63521"
+   x="392.94946"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan13015"
+     sodipodi:role="line"
+     x="392.94946"
+     y="238.63521">G</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="284.87436"
+   y="260.63519"
+   id="text13021"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     id="tspan13019"
+     x="284.87436"
+     y="260.63519">3</tspan><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     x="284.87436"
+     y="273.32486"
+     id="tspan2863">4</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="317.35983"
+   y="260.63519"
+   id="text13025"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="260.63519"
+     x="317.35983"
+     sodipodi:role="line"
+     id="tspan13023">6</tspan><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="273.32486"
+     x="317.35983"
+     sodipodi:role="line"
+     id="tspan2865">8</tspan></text>
+
+<text
+   id="text13029"
+   y="260.63519"
+   x="352.94946"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan13027"
+     sodipodi:role="line"
+     x="352.94946"
+     y="260.63519">6</tspan><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     x="352.94946"
+     y="273.32486"
+     id="tspan2867">2</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="392.94946"
+   y="260.63519"
+   id="text13033"><tspan
+     y="260.63519"
+     x="392.94946"
+     sodipodi:role="line"
+     id="tspan13031"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">G</tspan><tspan
+     y="273.32486"
+     x="392.94946"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2869">T</tspan></text>
+
+<text
+   id="text2811"
+   y="36.544128"
+   x="-92.784668"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"
+   transform="rotate(-90)"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2809"
+     sodipodi:role="line"
+     x="-92.784668"
+     y="36.544128">samples</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="188.6002"
+   y="18.660351"
+   id="text2815"><tspan
+     y="18.660351"
+     x="188.6002"
+     sodipodi:role="line"
+     id="tspan2813"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">sites</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="466.36859"
+   y="171.23354"
+   id="text3178"><tspan
+     y="171.23354"
+     x="466.36859"
+     sodipodi:role="line"
+     id="tspan3176"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">2</tspan></text>
+
+
+<text
+   id="text3182"
+   y="171.23354"
+   x="509.95819"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan3180"
+     sodipodi:role="line"
+     x="509.95819"
+     y="171.23354"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">C</tspan></text>
+
+
+
+
+
+
+<text
+   id="text3545"
+   y="182.7509"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3543"
+     sodipodi:role="line"
+     x="466.36859"
+     y="182.7509">4</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="182.7509"
+   id="text3549"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="182.7509"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3547">A</tspan></text>
+
+
+
+<text
+   id="text3559"
+   y="194.26826"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3557"
+     sodipodi:role="line"
+     x="466.36859"
+     y="194.26826">5</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="194.26826"
+   id="text3563"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="194.26826"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3561">C</tspan></text>
+
+
+
+<text
+   id="text3573"
+   y="205.78563"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3571"
+     sodipodi:role="line"
+     x="466.36859"
+     y="205.78563">7</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="205.78563"
+   id="text3577"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="205.78563"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3575">G</tspan></text>
+
+
+
+<text
+   id="text3588"
+   y="217.30299"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3586"
+     sodipodi:role="line"
+     x="466.36859"
+     y="217.30299">8</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="217.30299"
+   id="text3592"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="217.30299"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3590">C</tspan></text>
+
+
+
+<text
+   id="text3603"
+   y="228.82036"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3601"
+     sodipodi:role="line"
+     x="466.36859"
+     y="228.82036">9</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="228.82036"
+   id="text3607"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="228.82036"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3605">T</tspan></text>
+
+
+
+<text
+   id="text3617"
+   y="240.33771"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3615"
+     sodipodi:role="line"
+     x="466.36859"
+     y="240.33771">12</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="240.33771"
+   id="text3621"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="240.33771"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3619">T</tspan></text>
+
+
+
+<text
+   id="text3631"
+   y="251.85507"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3629"
+     sodipodi:role="line"
+     x="466.36859"
+     y="251.85507">15</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="251.85507"
+   id="text3635"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="251.85507"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3633">C</tspan></text>
+
+
+
+<text
+   id="text3645"
+   y="263.37244"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3643"
+     sodipodi:role="line"
+     x="466.36859"
+     y="263.37244">18</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="263.37244"
+   id="text3649"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="263.37244"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3647">G</tspan></text>
+
+
+
+<text
+   id="text3659"
+   y="274.8898"
+   x="466.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan3657"
+     sodipodi:role="line"
+     x="466.36859"
+     y="274.8898">19</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="509.95819"
+   y="274.8898"
+   id="text3663"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="274.8898"
+     x="509.95819"
+     sodipodi:role="line"
+     id="tspan3661">C</tspan></text>
+
+
+<text
+   id="text2110"
+   y="171.23354"
+   x="436.36859"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2108"
+     sodipodi:role="line"
+     x="436.36859"
+     y="171.23354">0</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="182.7509"
+   id="text2114"><tspan
+     y="182.7509"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2112"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">1</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="194.26826"
+   id="text2118"><tspan
+     y="194.26826"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2116"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">2</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="205.78563"
+   id="text2122"><tspan
+     y="205.78563"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2120"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">3</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="217.30299"
+   id="text2126"><tspan
+     y="217.30299"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2124"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">4</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="228.82036"
+   id="text2130"><tspan
+     y="228.82036"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2128"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">5</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="240.33771"
+   id="text2134"><tspan
+     y="240.33771"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2132"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">6</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="251.85507"
+   id="text2138"><tspan
+     y="251.85507"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2136"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">7</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="263.37244"
+   id="text2142"><tspan
+     y="263.37244"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2140"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">8</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="436.36859"
+   y="274.8898"
+   id="text2146"><tspan
+     y="274.8898"
+     x="436.36859"
+     sodipodi:role="line"
+     id="tspan2144"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">9</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="444.99255"
+   y="85.242859"
+   id="text2416"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     id="tspan2414"
+     x="444.99255"
+     y="85.242859">3</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="477.47815"
+   y="85.242859"
+   id="text2420"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="85.242859"
+     x="477.47815"
+     sodipodi:role="line"
+     id="tspan2418">0.0</tspan></text>
+
+<text
+   id="text2424"
+   y="65.585144"
+   x="290.56381"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="65.585144"
+     x="290.56381"
+     id="tspan2422"
+     sodipodi:role="line">0</tspan></text>
+
+<text
+   id="text2428"
+   y="65.585144"
+   x="323.04935"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2426"
+     sodipodi:role="line"
+     x="323.04935"
+     y="65.585144">20</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="399.28058"
+   y="65.590103"
+   id="text2432"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     id="tspan2430"
+     x="399.28058"
+     y="65.590103">1</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="358.63892"
+   y="65.58577"
+   id="text2436"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="65.58577"
+     x="358.63892"
+     sodipodi:role="line"
+     id="tspan2434">4</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="399.28058"
+   y="145.64223"
+   id="text2456"><tspan
+     id="tspan2454"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     x="399.28058"
+     y="145.64223">3</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="358.63892"
+   y="145.6416"
+   id="text2462"><tspan
+     id="tspan2460"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="145.6416"
+     x="358.63892"
+     sodipodi:role="line">6</tspan></text>
+
+<text
+   id="text2494"
+   y="132.37126"
+   x="399.28058"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="132.37126"
+     x="399.28058"
+     sodipodi:role="line"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2492">2</tspan></text>
+
+<text
+   id="text2498"
+   y="132.29814"
+   x="358.63892"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     sodipodi:role="line"
+     x="358.63892"
+     y="132.29814"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2496">6</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="323.04935"
+   y="105.61369"
+   id="text2526"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="105.61369"
+     x="323.04935"
+     sodipodi:role="line"
+     id="tspan2524">10</tspan></text>
+
+<text
+   id="text2530"
+   y="92.270851"
+   x="323.04935"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan2528"
+     sodipodi:role="line"
+     x="323.04935"
+     y="92.270851"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">10</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="323.04935"
+   y="118.95653"
+   id="text2534"><tspan
+     y="118.95653"
+     x="323.04935"
+     sodipodi:role="line"
+     id="tspan2532"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">20</tspan></text>
+
+<text
+   id="text2538"
+   y="132.29938"
+   x="323.04935"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2536"
+     sodipodi:role="line"
+     x="323.04935"
+     y="132.29938">20</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="323.04935"
+   y="145.64223"
+   id="text2542"><tspan
+     y="145.64223"
+     x="323.04935"
+     sodipodi:role="line"
+     id="tspan2540"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">20</tspan></text>
+
+<text
+   id="text2550"
+   y="118.95654"
+   x="285.04935"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan2548"
+     sodipodi:role="line"
+     x="285.04935"
+     y="118.95654"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">10</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="285.04935"
+   y="132.29938"
+   id="text2554"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="132.29938"
+     x="285.04935"
+     sodipodi:role="line"
+     id="tspan2552">10</tspan></text>
+
+<text
+   id="text2558"
+   y="145.64223"
+   x="285.04935"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan2556"
+     sodipodi:role="line"
+     x="285.04935"
+     y="145.64223"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">10</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="285.04935"
+   y="158.98508"
+   id="text2562"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="158.98508"
+     x="285.04935"
+     sodipodi:role="line"
+     id="tspan2560">10</tspan></text>
+
+<text
+   id="text2566"
+   y="158.98508"
+   x="323.04935"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     id="tspan2564"
+     sodipodi:role="line"
+     x="323.04935"
+     y="158.98508"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">20</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="284.87436"
+   y="248.63519"
+   id="text2573"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     id="tspan2568"
+     x="284.87436"
+     y="248.63519">2</tspan><tspan
+     id="tspan2571"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     sodipodi:role="line"
+     x="284.87436"
+     y="254.87454" /></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="317.35983"
+   y="248.63519"
+   id="text2577"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     y="248.63519"
+     x="317.35983"
+     sodipodi:role="line"
+     id="tspan2575">4</tspan></text>
+
+<text
+   id="text2581"
+   y="248.63519"
+   x="352.94946"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px"
+     id="tspan2579"
+     sodipodi:role="line"
+     x="352.94946"
+     y="248.63519">4</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="392.94946"
+   y="248.63519"
+   id="text2585"><tspan
+     y="248.63519"
+     x="392.94946"
+     sodipodi:role="line"
+     id="tspan2583"
+     style="font-size:10.15173626px;line-height:1.25;stroke-width:0.81213886px">T</tspan></text>
+
+<rect
+   style="opacity:1;fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:2.00314951;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.98823529"
+   id="rect2591"
+   width="20.872894"
+   height="94.992989"
+   x="177.12474"
+   y="21.367498" /><path
+   style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker4593)"
+   d="m 184.36636,118.91635 c -1.27793,24.28072 -15.76116,33.65222 8.94554,52.39524"
+   id="path2593"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="cc" /><path
+   style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
+   d="m 211.20295,182.387 c 77.52791,11.07542 19.33519,68.58238 70.02652,72.84216"
+   id="path3149"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="cc" /><rect
+   style="opacity:1;fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1"
+   id="rect4007"
+   width="130.34912"
+   height="12.353348"
+   x="280.63727"
+   y="250.54341" /><rect
+   style="opacity:1;fill:none;fill-opacity:1;stroke:#ff0000;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1"
+   id="rect4011"
+   width="95.418961"
+   height="12.779325"
+   x="432.08276"
+   y="230.2627" /><path
+   style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker2603)"
+   d="m 431.23081,233.93028 c -12.77933,0 6.59218,21.72485 -19.81843,21.29888"
+   id="path4013"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="cc" /></g><g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="trees"
+     style="display:inline;opacity:1"
+     transform="translate(-23.346868,-5.8920064)"><g
+   transform="translate(100,116)"
+   id="g2550"
+   style="display:inline;opacity:1"><path
+     sodipodi:nodetypes="cccc"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 84.862646,100.82168 120.54543,43.352827 97.758377,79.323072 110.00601,102.95157"
+     id="path2546"
+     inkscape:connector-curvature="0" /><path
+     sodipodi:nodetypes="cc"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 143.51388,101.98493 123.50824,48.524151"
+     id="path2548"
+     inkscape:connector-curvature="0" /><path
+     inkscape:connector-curvature="0"
+     id="path2364"
+     d="M 127.51388,101.98493 121.50824,48.524151"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="cc" /><path
+     sodipodi:nodetypes="cc"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 25.51388,101.98493 21.50824,48.524151"
+     id="path2366"
+     inkscape:connector-curvature="0" /></g><g
+   style="display:inline;opacity:1"
+   id="g2682"
+   transform="translate(0,116)"><path
+     inkscape:connector-curvature="0"
+     id="path2676"
+     d="m 84.862646,100.82168 16.888094,-79.619683 21.73249,26.59874 17.82166,53.020943"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="cccc" /><path
+     inkscape:connector-curvature="0"
+     id="path2678"
+     d="M 108.50597,102.08829 120.32763,48.222939"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="cc" /></g><text
+   id="text3596"
+   y="265.39136"
+   x="35.153412"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     style="font-size:12.18208313px;line-height:1.25;stroke-width:0.81213886px"
+     y="265.39136"
+     x="35.153412"
+     id="tspan3594"
+     sodipodi:role="line">Tree topologies and mutations</tspan></text>
+
+
+
+<g
+   style="display:inline;opacity:1"
+   id="g11769"
+   transform="translate(0,88)"><circle
+   r="6.1943111"
+   cy="48.468597"
+   cx="103.01733"
+   id="path4807"
+   style="fill:#84ff6c;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="99.795197"
+   y="51.334068"
+   id="text4900"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan4902"
+     x="99.795197"
+     y="51.334068">5</tspan></text>
+
+
+
+</g><g
+   style="display:inline;opacity:1"
+   id="g11753"
+   transform="translate(0,88)"><circle
+   style="fill:#08e8ff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle2652"
+   cx="121.01733"
+   cy="74.468597"
+   r="6.1943111" /><text
+   id="text2656"
+   y="77.334068"
+   x="118.00819"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="77.334068"
+     x="118.00819"
+     id="tspan2654"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">4</tspan></text>
+
+
+
+</g><g
+   style="display:inline;opacity:1"
+   id="g11761"
+   transform="translate(8,116)"><circle
+   r="6.1943111"
+   cy="102.4686"
+   cx="133.01733"
+   id="circle2658"
+   style="fill:#ffce46;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="130.00816"
+   y="105.33406"
+   id="text2662"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan2660"
+     x="130.00816"
+     y="105.33406">0</tspan></text>
+
+
+
+</g><g
+   style="display:inline;opacity:1"
+   id="g11736"
+   transform="translate(0,116)"><circle
+   r="6.1943111"
+   cy="102.4686"
+   cx="85.017326"
+   id="circle2670"
+   style="fill:#f2ff34;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="82.008186"
+   y="105.33406"
+   id="text2674"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan2672"
+     x="82.008186"
+     y="105.33406">3</tspan></text>
+
+
+
+</g><g
+   style="display:inline;opacity:1"
+   id="g11745"
+   transform="translate(16,116)"><circle
+   r="6.1943111"
+   cy="102.4686"
+   cx="109.01733"
+   id="circle4696"
+   style="fill:#fb95ff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   id="text2668"
+   y="105.33406"
+   x="106.00819"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="105.33406"
+     x="106.00819"
+     id="tspan2666"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">1</tspan></text>
+
+
+
+</g><g
+   transform="translate(100,88)"
+   id="g2566"
+   style="display:inline;opacity:1"><circle
+   r="6.1943111"
+   cy="74.468597"
+   cx="121.01733"
+   id="circle2560"
+   style="fill:#08e8ff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="118.00819"
+   y="77.334068"
+   id="text2564"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan2562"
+     x="118.00819"
+     y="77.334068">4</tspan></text>
+
+
+
+</g><g
+   transform="translate(112,116)"
+   id="g2574"
+   style="display:inline;opacity:1"><circle
+   style="fill:#ffce46;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle2568"
+   cx="133.01733"
+   cy="102.4686"
+   r="6.1943111" /><text
+   id="text2572"
+   y="105.33406"
+   x="130.00816"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="105.33406"
+     x="130.00816"
+     id="tspan2570"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">0</tspan></text>
+
+
+
+</g><circle
+   r="0"
+   style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="ellipse2576"
+   cx="209.01733"
+   cy="242.4686" /><g
+   id="g2382"><circle
+   style="fill:#a9ff95;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle2578"
+   cx="209.01733"
+   cy="218.4686"
+   r="6.1943111" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="206.00818"
+   y="221.33406"
+   id="text2582"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan2580"
+     x="206.00818"
+     y="221.33406">2</tspan></text>
+
+</g><g
+   transform="translate(100,116)"
+   id="g2592"
+   style="display:inline;opacity:1"><circle
+   style="fill:#f2ff34;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle2586"
+   cx="85.017326"
+   cy="102.4686"
+   r="6.1943111" /><text
+   id="text2590"
+   y="105.33406"
+   x="82.008186"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="105.33406"
+     x="82.008186"
+     id="tspan2588"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">3</tspan></text>
+
+
+
+</g><circle
+   style="fill:#ff6c96;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle2594"
+   cx="197.01733"
+   cy="194.4686"
+   r="6.1943111" /><text
+   id="text2598"
+   y="197.33408"
+   x="193.7952"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="197.33408"
+     x="193.7952"
+     id="tspan2596"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">6</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="30.043247"
+   y="18.78895"
+   id="text2807"><tspan
+     sodipodi:role="line"
+     id="tspan2805"
+     x="30.043247"
+     y="18.78895"
+     style="font-size:12.18208313px;line-height:1.25;stroke-width:0.81213886px">Genotype matrix:</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="28.231392"
+   y="238.06882"
+   id="text3038"><tspan
+     sodipodi:role="line"
+     id="tspan3062"
+     x="28.231392"
+     y="238.06882">Positions: </tspan></text>
+
+
+<text
+   id="text3054"
+   y="238.06882"
+   x="92.231392"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     sodipodi:role="line"
+     id="tspan3052"
+     x="92.231392"
+     y="238.06882">0 - 10</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="196.23138"
+   y="238.06882"
+   id="text3058"><tspan
+     y="238.06882"
+     x="196.23138"
+     id="tspan3056"
+     sodipodi:role="line">10-20</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="120.337"
+   y="311.11566"
+   id="text3066"><tspan
+     sodipodi:role="line"
+     id="tspan3064"
+     x="120.337"
+     y="322.91254" /></text>
+
+
+<g
+   id="g2377"><circle
+   style="fill:#a9ff95;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle2348"
+   cx="107.01733"
+   cy="218.4686"
+   r="6.1943111" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="104.00819"
+   y="221.33406"
+   id="text2352"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan2350"
+     x="104.00819"
+     y="221.33406">2</tspan></text>
+
+</g><g
+   style="display:inline;opacity:1"
+   id="g2362"
+   transform="translate(118,116)"><circle
+   r="6.1943111"
+   cy="102.4686"
+   cx="109.01733"
+   id="circle2356"
+   style="fill:#fb95ff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   id="text2360"
+   y="105.33406"
+   x="106.00819"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="105.33406"
+     x="106.00819"
+     id="tspan2358"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">1</tspan></text>
+
+
+
+</g></g><g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="genotypes"
+     style="display:inline;opacity:1"
+     transform="translate(-23.346868,-5.8920064)">
+
+
+
+
+
+<path
+   sodipodi:type="star"
+   style="opacity:1;fill:#ff0707;fill-opacity:1;stroke:#f70000;stroke-width:0.336375;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:1.3455, 0.336375;stroke-dashoffset:0;stroke-opacity:1"
+   id="path2766"
+   sodipodi:sides="5"
+   sodipodi:cx="97.169662"
+   sodipodi:cy="159.88596"
+   sodipodi:r1="2.9280276"
+   sodipodi:r2="2.9280276"
+   sodipodi:arg1="0.39852245"
+   sodipodi:arg2="1.026841"
+   inkscape:flatsided="false"
+   inkscape:rounded="0"
+   inkscape:randomized="0"
+   d="m 99.868236,161.0222 -1.183248,1.36918 -1.76205,0.41219 -1.667811,-0.70224 -0.936523,-1.54843 0.152485,-1.80319 1.183247,-1.36917 1.762051,-0.4122 1.667811,0.70224 0.936522,1.54843 z"
+   inkscape:transform-center-x="0.18071922"
+   inkscape:transform-center-y="0.48852665" /><path
+   inkscape:transform-center-y="0.48852665"
+   inkscape:transform-center-x="0.18071922"
+   d="m 208.33796,181.74577 -1.18324,1.36918 -1.76206,0.41219 -1.66781,-0.70223 -0.93652,-1.54844 0.15249,-1.80318 1.18324,-1.36918 1.76205,-0.4122 1.66781,0.70224 0.93653,1.54843 z"
+   inkscape:randomized="0"
+   inkscape:rounded="0"
+   inkscape:flatsided="false"
+   sodipodi:arg2="1.026841"
+   sodipodi:arg1="0.39852245"
+   sodipodi:r2="2.9280276"
+   sodipodi:r1="2.9280276"
+   sodipodi:cy="180.60953"
+   sodipodi:cx="205.63939"
+   sodipodi:sides="5"
+   id="path3577"
+   style="opacity:1;fill:#ff0707;fill-opacity:1;stroke:#f70000;stroke-width:0.336375;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:1.3455, 0.336375;stroke-dashoffset:0;stroke-opacity:1"
+   sodipodi:type="star" /><path
+   sodipodi:type="star"
+   style="opacity:1;fill:#ff0707;fill-opacity:1;stroke:#f70000;stroke-width:0.336375;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:1.3455, 0.336375;stroke-dashoffset:0;stroke-opacity:1"
+   id="path3579"
+   sodipodi:sides="5"
+   sodipodi:cx="203.54243"
+   sodipodi:cy="207.01923"
+   sodipodi:r1="2.9280276"
+   sodipodi:r2="2.9280276"
+   sodipodi:arg1="0.39852245"
+   sodipodi:arg2="1.026841"
+   inkscape:flatsided="false"
+   inkscape:rounded="0"
+   inkscape:randomized="0"
+   d="m 206.24101,208.15547 -1.18325,1.36918 -1.76205,0.41219 -1.66781,-0.70224 -0.93652,-1.54843 0.15248,-1.80319 1.18325,-1.36917 1.76205,-0.4122 1.66781,0.70224 0.93652,1.54843 z"
+   inkscape:transform-center-x="0.18071922"
+   inkscape:transform-center-y="0.48852665" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.89189911px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.49099165px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="85.221802"
+   y="159.32927"
+   id="text3583"><tspan
+     style="font-size:9.8198328px;line-height:1.25;stroke-width:0.49099165px"
+     sodipodi:role="line"
+     id="tspan3581"
+     x="85.221802"
+     y="159.32927">0</tspan></text>
+
+
+
+<text
+   id="text3587"
+   y="178.05127"
+   x="197.7211"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.89189911px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.49099165px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="178.05127"
+     x="197.7211"
+     id="tspan3585"
+     sodipodi:role="line"
+     style="font-size:9.8198328px;line-height:1.25;stroke-width:0.49099165px">3</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.89189911px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.49099165px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="206.31079"
+   y="205.34303"
+   id="text3591"><tspan
+     style="font-size:9.8198328px;line-height:1.25;stroke-width:0.49099165px"
+     sodipodi:role="line"
+     id="tspan3589"
+     x="206.31079"
+     y="205.34303">4</tspan></text>
+
+
+
+
+
+
+<text
+   id="text2843"
+   y="49.867668"
+   x="42.671722"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="49.867668"
+     x="42.671722"
+     id="tspan2841"
+     sodipodi:role="line"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px">0</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="42.791763"
+   y="69.14521"
+   id="text2847"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan2845"
+     x="42.791763"
+     y="69.14521">1</tspan></text>
+
+
+<text
+   id="text2851"
+   y="90.230019"
+   x="43.70694"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="90.230019"
+     x="43.70694"
+     id="tspan2849"
+     sodipodi:role="line"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px">2</tspan></text>
+
+
+<flowRoot
+   xml:space="preserve"
+   id="flowRoot2853"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><flowRegion
+     id="flowRegion2855"><rect
+       id="rect2857"
+       width="113.25555"
+       height="36.747814"
+       x="42.169621"
+       y="28.711441" /></flowRegion><flowPara
+     id="flowPara2859" /></flowRoot><path
+   inkscape:transform-center-y="0.48852665"
+   inkscape:transform-center-x="0.18071922"
+   d="m 117.84401,191.74577 -1.18325,1.36918 -1.76205,0.41219 -1.66781,-0.70223 -0.93653,-1.54844 0.15249,-1.80318 1.18325,-1.36918 1.76205,-0.4122 1.66781,0.70224 0.93652,1.54843 z"
+   inkscape:randomized="0"
+   inkscape:rounded="0"
+   inkscape:flatsided="false"
+   sodipodi:arg2="1.026841"
+   sodipodi:arg1="0.39852245"
+   sodipodi:r2="2.9280276"
+   sodipodi:r1="2.9280276"
+   sodipodi:cy="190.60953"
+   sodipodi:cx="115.14543"
+   sodipodi:sides="5"
+   id="path2877"
+   style="opacity:1;fill:#ff0707;fill-opacity:1;stroke:#f70000;stroke-width:0.336375;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:1.3455, 0.336375;stroke-dashoffset:0;stroke-opacity:1"
+   sodipodi:type="star" /><text
+   id="text2881"
+   y="190.05286"
+   x="103.19757"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.89189911px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.49099165px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="190.05286"
+     x="103.19757"
+     id="tspan2879"
+     sodipodi:role="line"
+     style="font-size:9.8198328px;line-height:1.25;stroke-width:0.49099165px">1</tspan></text>
+
+
+
+<text
+   id="text3158"
+   y="51.987701"
+   x="62.937149"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="51.987701"
+     x="62.937149"
+     id="tspan3156"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="62.937149"
+   y="71.987701"
+   id="text3162"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3160"
+     x="62.937149"
+     y="71.987701">C</tspan></text>
+
+
+<text
+   id="text3166"
+   y="91.987701"
+   x="62.937149"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="91.987701"
+     x="62.937149"
+     id="tspan3164"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="82.814217"
+   y="51.987701"
+   id="text3244"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3242"
+     x="82.814217"
+     y="51.987701">A</tspan></text>
+
+
+<text
+   id="text3248"
+   y="71.987701"
+   x="82.814217"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="82.814217"
+     id="tspan3246"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">A</tspan></text>
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="82.814217"
+   y="91.987701"
+   id="text3252"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3250"
+     x="82.814217"
+     y="91.987701">A</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="102.69128"
+   y="51.987701"
+   id="text3262"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3260"
+     x="102.69128"
+     y="51.987701">C</tspan></text>
+
+<text
+   id="text3266"
+   y="71.987701"
+   x="102.69128"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="102.69128"
+     id="tspan3264"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="102.69128"
+   y="91.987701"
+   id="text3270"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3268"
+     x="102.69128"
+     y="91.987701">G</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="122.56835"
+   y="51.987701"
+   id="text3280"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3278"
+     x="122.56835"
+     y="51.987701">G</tspan></text>
+
+<text
+   id="text3284"
+   y="71.987701"
+   x="122.56835"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="122.56835"
+     id="tspan3282"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">G</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="122.56835"
+   y="91.987701"
+   id="text3288"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3286"
+     x="122.56835"
+     y="91.987701">G</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="142.44542"
+   y="51.987701"
+   id="text3298"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3296"
+     x="142.44542"
+     y="51.987701">C</tspan></text>
+
+<text
+   id="text3302"
+   y="71.987701"
+   x="142.44542"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="142.44542"
+     id="tspan3300"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="142.44542"
+   y="91.987701"
+   id="text3306"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3304"
+     x="142.44542"
+     y="91.987701">C</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="162.32249"
+   y="51.987701"
+   id="text3316"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3314"
+     x="162.32249"
+     y="51.987701">T</tspan></text>
+
+<text
+   id="text3320"
+   y="71.987701"
+   x="162.32249"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="162.32249"
+     id="tspan3318"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">T</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="162.32249"
+   y="91.987701"
+   id="text3324"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3322"
+     x="162.32249"
+     y="91.987701">T</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="182.19955"
+   y="51.987701"
+   id="text3334"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3332"
+     x="182.19955"
+     y="51.987701">T</tspan></text>
+
+<text
+   id="text3338"
+   y="71.987701"
+   x="182.19955"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="182.19955"
+     id="tspan3336"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">T</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="182.19955"
+   y="91.987701"
+   id="text3342"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3340"
+     x="182.19955"
+     y="91.987701">G</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="202.07663"
+   y="51.987701"
+   id="text3352"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3350"
+     x="202.07663"
+     y="51.987701">C</tspan></text>
+
+<text
+   id="text3356"
+   y="71.987701"
+   x="202.07663"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="202.07663"
+     id="tspan3354"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="202.07663"
+   y="91.987701"
+   id="text3360"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3358"
+     x="202.07663"
+     y="91.987701">C</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="221.9537"
+   y="51.987701"
+   id="text3370"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3368"
+     x="221.9537"
+     y="51.987701">G</tspan></text>
+
+<text
+   id="text3374"
+   y="71.987701"
+   x="221.9537"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="221.9537"
+     id="tspan3372"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">G</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="221.9537"
+   y="91.987701"
+   id="text3378"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3376"
+     x="221.9537"
+     y="91.987701">T</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="241.83076"
+   y="51.987701"
+   id="text3388"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3386"
+     x="241.83076"
+     y="51.987701">C</tspan></text>
+
+<text
+   id="text3392"
+   y="71.987701"
+   x="241.83076"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="71.987701"
+     x="241.83076"
+     id="tspan3390"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="241.83076"
+   y="91.987701"
+   id="text3396"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3394"
+     x="241.83076"
+     y="91.987701">C</tspan></text>
+
+<text
+   id="text3170"
+   y="33.867668"
+   x="64.671722"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="33.867668"
+     x="64.671722"
+     id="tspan3168"
+     sodipodi:role="line"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px">0</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="84.54879"
+   y="33.867668"
+   id="text3256"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3254"
+     x="84.54879"
+     y="33.867668">1</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="104.42586"
+   y="33.867668"
+   id="text3274"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3272"
+     x="104.42586"
+     y="33.867668">2</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="124.30293"
+   y="33.867668"
+   id="text3292"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3290"
+     x="124.30293"
+     y="33.867668">3</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="144.17999"
+   y="33.867668"
+   id="text3310"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3308"
+     x="144.17999"
+     y="33.867668">4</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="164.05707"
+   y="33.867668"
+   id="text3328"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3326"
+     x="164.05707"
+     y="33.867668">5</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="183.93413"
+   y="33.867668"
+   id="text3346"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3344"
+     x="183.93413"
+     y="33.867668">6</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="203.8112"
+   y="33.867668"
+   id="text3364"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3362"
+     x="203.8112"
+     y="33.867668">7</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="223.68828"
+   y="33.867668"
+   id="text3382"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3380"
+     x="223.68828"
+     y="33.867668">8</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="243.56534"
+   y="33.867668"
+   id="text3400"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan3398"
+     x="243.56534"
+     y="33.867668">9</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="43.70694"
+   y="110.23002"
+   id="text2276"><tspan
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan2274"
+     x="43.70694"
+     y="110.23002">3</tspan></text>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="62.937149"
+   y="111.9877"
+   id="text2280"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan2278"
+     x="62.937149"
+     y="111.9877">C</tspan></text>
+
+<text
+   id="text2284"
+   y="111.9877"
+   x="82.814217"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="82.814217"
+     id="tspan2282"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">T</tspan></text>
+
+<text
+   id="text2288"
+   y="111.9877"
+   x="122.56835"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="122.56835"
+     id="tspan2286"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">G</tspan></text>
+
+<text
+   id="text2292"
+   y="111.9877"
+   x="142.44542"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="142.44542"
+     id="tspan2290"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">G</tspan></text>
+
+<text
+   id="text2296"
+   y="111.9877"
+   x="162.32249"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="162.32249"
+     id="tspan2294"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">T</tspan></text>
+
+<text
+   id="text2300"
+   y="111.9877"
+   x="182.19955"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="182.19955"
+     id="tspan2298"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">G</tspan></text>
+
+<text
+   id="text2304"
+   y="111.9877"
+   x="202.07663"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="202.07663"
+     id="tspan2302"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+<text
+   id="text2308"
+   y="111.9877"
+   x="221.9537"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="221.9537"
+     id="tspan2306"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">G</tspan></text>
+
+<text
+   id="text2312"
+   y="111.9877"
+   x="241.83076"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="241.83076"
+     id="tspan2310"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+<text
+   id="text2324"
+   y="111.9877"
+   x="102.69128"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="111.9877"
+     x="102.69128"
+     id="tspan2322"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">C</tspan></text>
+
+<path
+   inkscape:transform-center-y="0.48852665"
+   inkscape:transform-center-x="0.18071922"
+   d="m 115.86824,151.0222 -1.18325,1.36918 -1.76205,0.41219 -1.66781,-0.70224 -0.93653,-1.54843 0.15249,-1.80319 1.18325,-1.36917 1.76205,-0.4122 1.66781,0.70224 0.93652,1.54843 z"
+   inkscape:randomized="0"
+   inkscape:rounded="0"
+   inkscape:flatsided="false"
+   sodipodi:arg2="1.026841"
+   sodipodi:arg1="0.39852245"
+   sodipodi:r2="2.9280276"
+   sodipodi:r1="2.9280276"
+   sodipodi:cy="149.88596"
+   sodipodi:cx="113.16966"
+   sodipodi:sides="5"
+   id="path2522"
+   style="opacity:1;fill:#ff0707;fill-opacity:1;stroke:#f70000;stroke-width:0.336375;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:1.3455, 0.336375;stroke-dashoffset:0;stroke-opacity:1"
+   sodipodi:type="star" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.89189911px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.49099165px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="115.7211"
+   y="148.05127"
+   id="text2589"><tspan
+     style="font-size:9.8198328px;line-height:1.25;stroke-width:0.49099165px"
+     sodipodi:role="line"
+     id="tspan2587"
+     x="115.7211"
+     y="148.05127">2</tspan></text>
+
+</g><g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="intervals"
+     style="display:none"
+     transform="translate(-23.346868,-5.8920064)"><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.7456665px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="35.153412"
+   y="149.39137"
+   id="text3602"><tspan
+     sodipodi:role="line"
+     id="tspan3600"
+     x="35.153412"
+     y="149.39137"
+     style="font-size:12.18208313px;line-height:1.25;stroke-width:0.81213886px">Intervals:</tspan></text>
+
+
+
+</g><g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="interval_labels"
+     style="display:none"
+     transform="translate(-23.346868,-5.8920064)"><path
+       inkscape:connector-curvature="0"
+       id="path5026"
+       d="M 69.982209,165.64134 H 259.97321"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker8042);marker-end:url(#marker8666)" /><path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker7864);marker-end:url(#marker8656)"
+       d="M 69.982209,187.64134 H 259.97321"
+       id="path5028"
+       inkscape:connector-curvature="0" /><path
+       sodipodi:nodetypes="cc"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#StopL);marker-end:url(#marker8434)"
+       d="M 69.982209,233.64134 H 163.97321"
+       id="path5030"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       id="path5032"
+       d="M 69.982209,209.64134 H 163.97321"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker6206);marker-end:url(#marker6462)"
+       sodipodi:nodetypes="cc" /><path
+       sodipodi:nodetypes="cc"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker7692);marker-end:url(#marker8646)"
+       d="m 165.98221,209.64134 h 93.991"
+       id="path5034"
+       inkscape:connector-curvature="0" /><path
+       inkscape:connector-curvature="0"
+       id="path5036"
+       d="m 165.98221,233.64134 h 93.991"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker8226);marker-end:url(#marker8862)"
+       sodipodi:nodetypes="cc" /><g
+       id="g11853"><circle
+   r="6.1943111"
+   cy="160.71317"
+   cx="184.91397"
+   id="circle5048"
+   style="fill:#08e8ff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="181.90482"
+   y="163.57863"
+   id="text5052"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan5050"
+     x="181.90482"
+     y="163.57863">3</tspan></text>
+
+
+
+</g><path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5038"
+       d="m 150.64468,159.93069 h 28.24386"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker7088)" /><g
+       id="g11861"><circle
+   r="6.1943111"
+   cy="160.71317"
+   cx="146.91397"
+   id="circle5040"
+   style="fill:#fb95ff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   id="text5044"
+   y="163.57863"
+   x="144.19846"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="163.57863"
+     x="144.19846"
+     id="tspan5042"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">1</tspan></text>
+
+
+
+</g><g
+       id="g11845"><circle
+   style="fill:#84ff6c;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle5069"
+   cx="184.91397"
+   cy="182.71317"
+   r="6.1943111" /><text
+   id="text5073"
+   y="185.57863"
+   x="181.90482"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="185.57863"
+     x="181.90482"
+     id="tspan5071"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">4</tspan></text>
+
+
+
+</g><path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker7368)"
+       d="m 150.64468,181.93069 h 28.24386"
+       id="path5059"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" /><g
+       transform="matrix(0.6,0,0,0.6,62.303575,70.832)"
+       id="g5067"><circle
+   style="fill:#08e8ff;fill-opacity:1;stroke:#000000;stroke-width:0.96053487;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle5061"
+   cx="141.01733"
+   cy="186.4686"
+   r="10.323852" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="135.78154"
+   y="191.24438"
+   id="text5065"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan5063"
+     x="135.78154"
+     y="191.24438">3</tspan></text>
+
+
+
+</g><g
+       id="g11869"><circle
+   r="6.1943111"
+   cy="204.71317"
+   cx="138.91397"
+   id="circle5089"
+   style="fill:#08e8ff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="136.1178"
+   y="207.57863"
+   id="text5093"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan5091"
+     x="136.1178"
+     y="207.57863">3</tspan></text>
+
+
+
+</g><g
+       id="g11877"><circle
+   style="fill:#84ff6c;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle5109"
+   cx="138.91397"
+   cy="228.71317"
+   r="6.1943111" /><text
+   id="text5113"
+   y="231.57863"
+   x="135.90482"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="231.57863"
+     x="135.90482"
+     id="tspan5111"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">4</tspan></text>
+
+
+
+</g><path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5079"
+       d="m 104.64468,203.93069 h 28.24386"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker7666)" /><g
+       transform="matrix(0.6,0,0,0.6,41.903575,82.032)"
+       id="g5087"><circle
+   r="10.323852"
+   cy="204.4686"
+   cx="95.017334"
+   id="circle5081"
+   style="fill:#ffce46;fill-opacity:1;stroke:#000000;stroke-width:0.96053487;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   id="text5085"
+   y="209.24438"
+   x="89.78154"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="209.24438"
+     x="89.78154"
+     id="tspan5083"
+     sodipodi:role="line"
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px">0</tspan></text>
+
+
+
+</g><path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker7958)"
+       d="m 104.64468,227.93069 h 28.24386"
+       id="path5099"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" /><g
+       id="g11885"><circle
+   style="fill:#f2ff34;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle5101"
+   cx="98.913979"
+   cy="228.71317"
+   r="6.1943111" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="96.198479"
+   y="231.57863"
+   id="text5105"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan5103"
+     x="96.198479"
+     y="231.57863">2</tspan></text>
+
+
+
+</g><g
+       id="g11829"><circle
+   r="6.1943111"
+   cy="228.71317"
+   cx="238.91397"
+   id="circle5129"
+   style="fill:#08e8ff;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="236.4707"
+   y="231.57863"
+   id="text5133"><tspan
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px"
+     sodipodi:role="line"
+     id="tspan5131"
+     x="236.4707"
+     y="231.57863">3</tspan></text>
+
+
+
+</g><path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5119"
+       d="m 204.64468,227.93069 h 28.24386"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8262)" /><g
+       id="g11821"><circle
+   style="fill:#84ff6c;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle5147"
+   cx="238.91397"
+   cy="204.71317"
+   r="6.1943111" /><text
+   id="text5151"
+   y="207.57863"
+   x="235.86829"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="207.57863"
+     x="235.86829"
+     id="tspan5149"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">4</tspan></text>
+
+
+
+</g><g
+       id="g11837"><circle
+   r="6.1943111"
+   cy="228.71317"
+   cx="198.91397"
+   id="circle5121"
+   style="fill:#f2ff34;fill-opacity:1;stroke:#000000;stroke-width:0.57632095;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><text
+   id="text5125"
+   y="231.57863"
+   x="196.2243"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.53268051px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.46105674px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     y="231.57863"
+     x="196.2243"
+     id="tspan5123"
+     sodipodi:role="line"
+     style="font-size:9.22113514px;line-height:1.25;stroke-width:0.46105674px">2</tspan></text>
+
+
+
+</g><g
+       transform="matrix(0.6,0,0,0.6,81.903574,82.032)"
+       id="g5145"><circle
+   style="fill:#ffce46;fill-opacity:1;stroke:#000000;stroke-width:0.96053487;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+   id="circle5139"
+   cx="195.01733"
+   cy="204.4686"
+   r="10.323852" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.22113419px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76842791px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="189.78154"
+   y="209.24438"
+   id="text5143"><tspan
+     style="font-size:15.36855793px;line-height:1.25;stroke-width:0.76842791px"
+     sodipodi:role="line"
+     id="tspan5141"
+     x="189.78154"
+     y="209.24438">0</tspan></text>
+
+
+
+</g><path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker6805)"
+       d="m 204.64468,203.93069 h 28.24386"
+       id="path5155"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" /></g><g
+     inkscape:groupmode="layer"
+     id="layer8"
+     inkscape:label="interval_scale"
+     style="display:none"><path
+   transform="translate(-23.346868,-5.8920064)"
+   sodipodi:nodetypes="ccscscscscc"
+   inkscape:connector-curvature="0"
+   id="path10718"
+   d="m 70.190685,249.39264 h 19.032304 19.032321 19.0323 19.03232 19.0323 19.03233 19.27315 19.27317 18.35106 18.35109"
+   style="display:inline;opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker10722);marker-mid:url(#marker10960);marker-end:url(#marker11204)" /><g
+   transform="translate(-23.346868,-5.8920064)"
+   style="display:inline;opacity:1"
+   id="g11608"><text
+   id="text12642"
+   y="263.94305"
+   x="67.124779"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     sodipodi:role="line"
+     id="tspan12640"
+     x="67.124779"
+     y="263.94305">0</tspan></text>
+
+
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   x="162.27283"
+   y="263.94305"
+   id="text12646"><tspan
+     y="263.94305"
+     x="162.27283"
+     id="tspan12644"
+     sodipodi:role="line">5</tspan></text>
+
+
+
+<text
+   id="text12650"
+   y="263.94305"
+   x="254.27283"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     sodipodi:role="line"
+     id="tspan12648"
+     x="254.27283"
+     y="263.94305">10</tspan></text>
+
+
+
+</g><text
+   transform="translate(-23.346868,-5.8920064)"
+   id="text12847"
+   y="274.16571"
+   x="117.99245"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.33333302px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.81213886px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+   xml:space="preserve"><tspan
+     sodipodi:role="line"
+     id="tspan12849"
+     x="117.99245"
+     y="274.16571">Genomic position</tspan></text>
+
+
+</g></svg>

--- a/paper.bib
+++ b/paper.bib
@@ -929,15 +929,17 @@ pages = {919--925},
     pages = {164--166},
 }
 
-@article{ralph2019efficiently,
-  author = {Ralph, Peter and Thornton, Kevin and Kelleher, Jerome},
-  journal = {bioRxiv},
-  keywords = {local_adaptation myown simulation stickleback swamping},
-  publisher = {Cold Spring Harbor Laboratory},
-  title = {Efficiently summarising relationships in large samples: a general duality between statistics of genealogies and genomes},
-  year = 2019
+@article{ralph2020efficiently,
+    title={Efficiently summarizing relationships in large samples: a general
+        duality between statistics of genealogies and genomes},
+    author={Ralph, Peter and Thornton, Kevin and Kelleher, Jerome},
+    journal={Genetics},
+    volume={215},
+    number={3},
+    pages={779--797},
+    year={2020},
+    publisher={Oxford University Press}
 }
-
 
 @article{baumdicker2014AGTG,
 author = {Baumdicker, Franz and Pfaffelhuber, Peter},
@@ -1582,6 +1584,25 @@ year = {2016}
     pages={1021--1030},
     year={2016},
     publisher={Oxford University Press}
+}
+
+@article{cardona2008extended,
+    author = {Gabriel Cardona and Francesc Rossell\'o and Gabriel Valiente},
+    title = {Extended {Newick}: it is time for a standard 
+        representation of phylogenetic networks}, 
+    year = {2008},
+    journal = {BMC Bioinformatics},
+    volume = {9},
+    pages = {532},
+}
+
+@article{mcgill2013graphml,
+    title={{GraphML} specializations to codify ancestral recombinant graphs},
+    author={McGill, James R and Walkup, Elizabeth A and Kuhner, Mary K},
+    journal={Fron Genet},
+    volume={4},
+    pages = {146},
+    year={2013},
 }
 
 =======

--- a/paper.bib
+++ b/paper.bib
@@ -1498,6 +1498,16 @@ year = {2016}
     publisher={Oxford University Press}
 }
 
+@article{sanchez2020deep,
+    title={Deep learning for population size history inference: Design,
+        comparison and combination with approximate Bayesian computation},
+    author={Sanchez, Th{\'e}ophile and Cury, Jean and Charpiat, Guillaume
+        and Jay, Flora},
+    journal={Molecular Ecology Resources},
+    year={2020},
+    publisher={Wiley Online Library}
+}
+
 @article{spence2019inference,
     title={Inference and analysis of population-specific fine-scale 
         recombination maps across 26 diverse human populations},
@@ -1603,6 +1613,70 @@ year = {2016}
     volume={4},
     pages = {146},
     year={2013},
+}
+
+@article{quinto2018modeling,
+    title={Modeling SNP array ascertainment with Approximate Bayesian
+        Computation for demographic inference},
+    author={Quinto-Cort{\'e}s, Consuelo D and Woerner, August E and
+        Watkins, Joseph C and Hammer, Michael F},
+    journal={Scientific reports},
+    volume={8},
+    number={1},
+    pages={1--10},
+    year={2018},
+    publisher={Nature Publishing Group}
+}
+
+@article{chen2013asymptotic,
+    title={Asymptotic distributions of coalescence times and ancestral
+        lineage numbers for populations with temporally varying size},
+    author={Chen, Hua and Chen, Kun},
+    journal={Genetics},
+    volume={194},
+    number={3},
+    pages={721--736},
+    year={2013},
+    publisher={Oxford University Press}
+}
+
+@article{racimo2017archaic,
+    title={Archaic adaptive introgression in TBX15/WARS2},
+    author={Racimo, Fernando and Gokhman, David and Fumagalli, Matteo and
+        Ko, Amy and Hansen, Torben and Moltke, Ida and Albrechtsen, Anders
+            and Carmel, Liran and Huerta-S{\'a}nchez, Emilia and Nielsen,
+        Rasmus},
+    journal={Molecular Biology and Evolution},
+    volume={34},
+    number={3},
+    pages={509--524},
+    year={2017},
+    publisher={Oxford University Press}
+}
+
+@article{pavlidis2010msabc,
+    title={{msABC}: a modification of Hudson’s ms to facilitate multi-locus ABC
+        analysis},
+    author={Pavlidis, Pavlos and Laurent, Stefan and Stephan, Wolfgang},
+    journal={Molecular Ecology Resources},
+    volume={10},
+    number={4},
+    pages={723--727},
+    year={2010},
+    publisher={Wiley Online Library}
+}
+
+@article{rosenzweig2016powerful,
+    title={Powerful methods for detecting introgressed regions from
+        population genomic data},
+    author={Rosenzweig, Benjamin K and Pease, James B and Besansky, Nora J
+        and Hahn, Matthew W},
+    journal={Molecular ecology},
+    volume={25},
+    number={11},
+    pages={2387--2397},
+    year={2016},
+    publisher={Wiley Online Library}
 }
 
 =======

--- a/paper.tex
+++ b/paper.tex
@@ -12,7 +12,7 @@
 \usepackage{verbatim}%
 \usepackage{environ}%
 \usepackage[right]{lineno}%
-\usepackage{microtype}
+\usepackage{nameref}
 %\usepackage{showkeys}
 
 % local definitions
@@ -163,6 +163,7 @@ point in listing it out section by section.}
 % to be extended by addition of new features while ensuring robustness and
 % maintainability of the core codebase.
 
+\label{sec-ts}
 \subsection*{Tree sequences}
 One of the key reasons for \msprime's significiant performance advantage
 over other simulators is its usage of the ``succinct tree sequence''
@@ -182,8 +183,47 @@ for four samples at ten sites.
 }
 \end{figure}
 
-\jkcomment{Paragraph describing what a tree sequence is, referring to
-Fig.~\ref{fig-ts-example}.}
+The succinct tree sequence is a data structure for concisely encoding
+genetic ancestry. Given a set of sample chromosomes, the topology
+of their genetic ancestry is described by a set of \emph{nodes}
+and \emph{edges}. A node in tree sequence terminology corresponds
+to a single chromosome strand, and is associated with its birth time,
+birth population and other metadata. A node may optionally be
+associated with an \emph{individual}, so that, for example, a diploid
+individual will be associated with two separate nodes (we omit
+the individual table in Fig.~\ref{fig-ts-example} as it is optional).
+Nodes define haplotypes that exist at a specific time within a
+specific individual, and edges define genetic inheritence
+relationships between these nodes. An edge consists of a
+parent node, a child node and the left and right coordinates
+of the contiguous genomic interval over which
+the child inherited genetic material from the parent.
+Critically, edges can span multiple marginal trees: for
+example, in Fig.~\ref{fig-ts-example} the branch from node
+0 to 4 is present in both marginal trees, and represented
+by a single edge (the first row in the example edge table).
+This simple device, of explicitly associating tree nodes
+with specific ancestral chromosomes and recording the
+genomic intervals over which parent/child relationships exist,
+is a generalisation from the original concept  of
+``coalescence records''~\citep{kelleher2016efficient}, and
+is the key to the efficiency of tree sequences.
+\jkcomment{Summarise and add references?}
+As discussed in the \ref{sec-mutations} section, tree sequences
+can also store genetic variation data very efficiently.
+
+The term Ancestral Recombination Graph (ARG) is often understood
+to mean the complete record of a sample's genetic
+ancestry~\citep[e.g.][]{mathieson2020ancestry}, and in this sense a tree
+sequence \emph{is} an ARG. More technically, an ARG is a particular
+graphical representation of genetic ancestry based on the
+flow of ancestral material through recombination and common
+ancestor events~\citep{griffiths1991two,griffiths1997ancestral}.
+In this sense, tree sequences can be used to \emph{encode}
+ARGs without loss of information---although we do not store
+the additional ARG information by default
+in \msprime\ because the minimal tree sequence encoding is
+much more concise (see the \nameref{sec-arg} section for more details).
 
 
 The point of simulations is to generate data and the efficiency with
@@ -264,6 +304,7 @@ the models and statistics of most interest.
 \end{itemize}
 
 
+\label{sec-mutations}
 \subsection*{Finite sites mutations}
 Version 0.x of \texttt{msprime} provided a very simple mutation model,
 supporting only the infinite sites model.
@@ -640,8 +681,8 @@ spectrum~\citep{birkner2013statistical,blath2016site,hobolth2019phase}
  as well as more general properties of coalescent processes.
 Please see the Appendix for more details and model derivations.
 
-
-\subsection*{Ancestral recombination graphs}
+\subsection*{Ancestral Recombination Graphs}
+\label{sec-arg}
 
 The Ancestral Recombination Graph (ARG) was introduced by
 Griffiths~\citep{griffiths1991two,griffiths1997ancestral} as a graphical

--- a/paper.tex
+++ b/paper.tex
@@ -136,6 +136,11 @@ This paper marks the release of \msprime\ 1.0.
 
 \section*{Results}
 
+\jkcomment{We should trim this down quite a bit - all we want to do is some basic
+roadmapping, like, we discuss the underlying tree sequence object,
+then mutations (because it's quite separate from the rest)
+and then a bunch of new features for ancestry simulation. There's no
+point in listing it out section by section.}
 In this section we describe the main features of \msprime\ 1.0. Methodologically,
 there exists a logical separation between simulating coalescent genealogies and
 adding neutral mutations onto these genealogies. Simulating genetic ancestry
@@ -153,6 +158,189 @@ and highlight the open source development process which allows for \msprime\
 to be extended by addition of new features while ensuring robustness and
 maintainability of the core codebase.
 
+\subsection*{Tree sequences}
+One of the key reasons for \msprime's significiant performance advantage
+over other simulators is its usage of the ``succinct tree sequence''
+(usually, tree sequence) data stucture and the supporting \tskit\
+library~\citep{tskit2021tskit}.
+While a full discussion of tree sequences and the capabilities
+of \tskit\ is beyond the scope of this article, we briefly summarise
+here.
+
+\begin{figure}
+\begin{center}
+\includegraphics[width=6cm]{figures/example_tree_sequence}
+\end{center}
+\caption{\label{fig-ts-example} Example tree sequence.
+An example tree sequence describing genealogies and genotypes
+for four samples at ten sites.
+}
+\end{figure}
+
+\jkcomment{Paragraph describing what a tree sequence is, referring to
+Fig.~\ref{fig-ts-example}.}
+
+
+The point of simulations is to generate data and the efficiency with
+which simulated data can be incorporated into an overall application
+is an important issue.
+For example, Approximate Bayesian Computation
+(ABC)~\citep{beaumont2002approximate,csillery2010approximate,wegmann2010abctoolbox}
+and more recent machine learning
+methods~\citep{sheehan2016deep,schrider2018supervised,flagel2019unreasonable}
+perform population genetic inference by using large numbers of
+simulations as training data. Clearly, simulation efficiency is
+crucial since the size and number of simulations that can be performed determines
+the depth to which the model and parameter space can be sampled from.
+Equally important,
+however, is the efficiency with which the simulation results can be
+transformed into the specific input required by the inference method.
+In the case of ABC, this is usually a set of summary statistics of the sequence data.
+Modern approaches such as
+ABC-RF~\citep{raynal2019abc,pudlo2016abc} and
+ABC-NN~\citep{csillery2012abc,blum2010abc} can accommodate large
+numbers of user-specified statistics that are individually weakly informative,
+but jointly close to sufficient for the desired model or parameter.
+However, the computational resources needed to calculate these statistics can be even
+greater than those used to generate the simulated datasets.
+Older software such as DIYABC~\citep{cornuet2008inferring}
+or PopABC~\citep{lopes2009popabc} avoid this bottleneck by
+developing their own specialised simulators, tightly integrating them
+with the inference method. While this is certainly more efficient,
+there is a great deal of duplication of effort and significant
+room for error.
+As ABC inference has become useful in an ever-widening range of applications,
+these all-in-one methods risk falling behind if they do not allow users to explore
+the models and statistics of most interest.
+
+\jkcomment{Stuff to cover}
+\begin{itemize}
+
+\item The core problem is that the field lacked an efficient mechanism for
+    interchanging simulated data, and so developers were forced to choose
+    between efficiency and duplication of effort.
+
+\item What are the output formats of simulators? Newick, or sequence data
+    basically. What's the problem with this? We don't have mutations.
+    Much more efficient to have the tree and mutations than the
+    sequence data. Fundamentally, the output of coalescent simulations
+    should be trees, otherwise we are throwing a lot of information
+    away.
+
+\item Lots of examples of papers where people have been forced to
+    create a modified fork of some simulator so that they can get
+    access to some internal details, not exposed by the simulators
+    interface. Tree sequences provide a complete record of the
+    ancestral process, so we can do things like compute IBD
+    segments and introgressed tracts directly on the output. See
+    also ARG section for recording more information, though.
+
+\item Side note somewhere: with efficient access to branch length
+    statistics~\citep{ralph2019efficiently}, maybe we don't need to
+    simulate mutations at all. (not in the ABC context, but elsewhere)
+
+\item Msprime uses the \tskit\ library~\citep{tskit2021tskit}, which provides
+    extremely efficient interchange and data processing. A quick example
+    of how efficient.
+
+\item Tskit has facilited unprecedented interoperability between simulators:
+    Forward simulations can also use tree
+    sequences~\citep{kelleher2018efficient,haller2018tree}. In particular, SLiM
+    3.0~\citep{haller2019slim} and fwdpp~\citep{thornton2014cpp} can now output
+    tree sequences. Msprime can take tree sequences simulated by these forward
+    simulators as input and complete the simulation (``recapitation'').
+    See \cite{haller2018tree} for more details.
+    (Although, this could be a discussion point?)
+
+\item Recently, Phastsim/USHER~\cite{demaio2021phastsim,turakhia2021ultrafast}
+    have used this idea of storing the
+    tree plus mutations, but approach is crude compared to tskit.
+
+\end{itemize}
+
+
+\subsection*{Finite sites mutations}
+Version 0.x of \texttt{msprime} provided a very simple mutation model,
+supporting only the infinite sites model.
+With version 1.0, we now support a large number of mutation models,
+including
+JC69~\citep{jukes1969evolution},
+F84~\citep{felsenstein1996hidden},
+and GTR~\citep{tavare1986some} nucleotide models
+and the BLOSUM62~\citep{henikoff1992amino}
+and PAM~\citep{dayhoff1978} amino acid models.
+The general model accepts an arbitrary transition matrix between
+any number of alleles (which can be arbitrary unicode strings),
+and so other models such as the Kimura two and three
+parameter models~\citep{kimura1980simple,kimura1981estimation}
+parameters models can be easily
+and efficiently defined in user code.
+Full support for the original infinite sites model is also maintained.
+The results of mutation simulations across a range of models are
+extensively validated
+against both theoretical expectations and output from
+Seq-Gen~\citep{rambaut1997seq} and
+Pyvolve~\citep{spielman2015pyvolve}.
+
+\begin{figure}
+\includegraphics[width=\textwidth]{figures/mutations-perf}
+\caption{\label{fig-mutations-perf} Time required to run
+\texttt{sim\_mutations} on tree sequences generated
+by \texttt{sim\_ancestry} (with a population size of $10^4$
+and recombination rate of $10^{-8}$) for varying (haploid) sample
+size and sequence length. We run 10 replicate mutation simulations
+each for three different mutation rates, and report the average
+CPU time required (Intel Core i7-9700).
+(A) Holding sequence length fixed at 10 megabases and varying the
+number of samples (tree tips) from 10 to 100,000.
+(B) Holding number of samples fixed at 1000, and varying the sequence
+length from 1 to 100 megabases.}
+\end{figure}
+
+Comparing the performance of mutation generation methods is problematic.
+Because there is no standard format for representing trees and
+the accompanying mutations, all existing methods are focused on
+writing out the resulting sequences. Methods are also not modular,
+and so it is very difficult to disentangle the time required to
+read in the tree file and output the sequences from the actual
+time required to perform the simulation.
+
+Fig.~\ref{fig-mutations-perf} shows that the mutation generation
+machinery in \msprime\ is extremely efficient, requiring
+fractions of a second to generate mutations for most simulations.
+For example, the longest running simulation in
+Fig.~\ref{fig-mutations-perf}B required less than 2 seconds to
+generate an average of 1.5 million mutations over 137,081 trees
+in a tree sequence with 508,125 edges.
+Generating mutations for a tree sequence is particularly efficient
+because we can work edge-by-edge rather than having to
+consider each tree independently.
+
+\jkcomment{We probably want to keep a version of this narrative too.}
+For example, we simulated mutations under the JC69
+model for a tree with $10^6$ leaves over $10^4$ sites (resulting
+in $\sim 280000$ mutations) in less that 1.5 seconds, including
+the time required for file input and output. While a systematic
+comparison of run-times is not feasible here, this is orders
+of magnitude faster than methods such as
+Seq-Gen~\citep{rambaut1997seq} and
+Pyvolve~\citep{spielman2015pyvolve}
+and at least competitive with the recent method from
+\cite{demaio2021phastsim}.
+
+\textbf{TODO: would love to do a like-for-like comparison, but quite hard}
+
+Another substantial advantage of our approach is that the simulated
+mutations are stored directly in the output data format with
+a defined API. Although
+Pyvolve and Phastsim are implemented in Python, neither provide
+programatic access to the simulated output, outputting instead
+to a series of files which must subsequently be parsed.
+See the Data Model section for more details and discussion.
+
+Things we can do: future work will need to do things like
+Dawg~\citep{cartwright2005dna} and to implement models and
+indels~\citep{fletcher2009indelible}.
 
 \subsection*{Recombination}
 
@@ -611,88 +799,6 @@ simulator.  The Wright-Fisher approach in \msprime\ is more efficient at
 simulating chromosome-scale sequences (larger than $\approx10$Mb), while the
 hybrid approach provides large efficiency gains.
 
-\subsection*{Finite sites mutations}
-Version 0.x of \texttt{msprime} provided a very simple mutation model,
-supporting only the infinite sites model.
-With version 1.0, we now support a large number of mutation models,
-including
-JC69~\citep{jukes1969evolution},
-F84~\citep{felsenstein1996hidden},
-and GTR~\citep{tavare1986some} nucleotide models
-and the BLOSUM62~\citep{henikoff1992amino}
-and PAM~\citep{dayhoff1978} amino acid models.
-The general model accepts an arbitrary transition matrix between
-any number of alleles (which can be arbitrary unicode strings),
-and so other models such as the Kimura two and three
-parameter models~\citep{kimura1980simple,kimura1981estimation}
-parameters models can be easily
-and efficiently defined in user code.
-Full support for the original infinite sites model is also maintained.
-The results of mutation simulations across a range of models are
-extensively validated
-against both theoretical expectations and output from
-Seq-Gen~\citep{rambaut1997seq} and
-Pyvolve~\citep{spielman2015pyvolve}.
-
-\begin{figure}
-\includegraphics[width=\textwidth]{figures/mutations-perf}
-\caption{\label{fig-mutations-perf} Time required to run
-\texttt{sim\_mutations} on tree sequences generated
-by \texttt{sim\_ancestry} (with a population size of $10^4$
-and recombination rate of $10^{-8}$) for varying (haploid) sample
-size and sequence length. We run 10 replicate mutation simulations
-each for three different mutation rates, and report the average
-CPU time required (Intel Core i7-9700).
-(A) Holding sequence length fixed at 10 megabases and varying the
-number of samples (tree tips) from 10 to 100,000.
-(B) Holding number of samples fixed at 1000, and varying the sequence
-length from 1 to 100 megabases.}
-\end{figure}
-
-Comparing the performance of mutation generation methods is problematic.
-Because there is no standard format for representing trees and
-the accompanying mutations, all existing methods are focused on
-writing out the resulting sequences. Methods are also not modular,
-and so it is very difficult to disentangle the time required to
-read in the tree file and output the sequences from the actual
-time required to perform the simulation.
-
-Fig.~\ref{fig-mutations-perf} shows that the mutation generation
-machinery in \msprime\ is extremely efficient, requiring
-fractions of a second to generate mutations for most simulations.
-For example, the longest running simulation in
-Fig.~\ref{fig-mutations-perf}B required less than 2 seconds to
-generate an average of 1.5 million mutations over 137,081 trees
-in a tree sequence with 508,125 edges.
-Generating mutations for a tree sequence is particularly efficient
-because we can work edge-by-edge rather than having to
-consider each tree independently.
-
-\jkcomment{We probably want to keep a version of this narrative too.}
-For example, we simulated mutations under the JC69
-model for a tree with $10^6$ leaves over $10^4$ sites (resulting
-in $\sim 280000$ mutations) in less that 1.5 seconds, including
-the time required for file input and output. While a systematic
-comparison of run-times is not feasible here, this is orders
-of magnitude faster than methods such as
-Seq-Gen~\citep{rambaut1997seq} and
-Pyvolve~\citep{spielman2015pyvolve}
-and at least competitive with the recent method from
-\cite{demaio2021phastsim}.
-
-\textbf{TODO: would love to do a like-for-like comparison, but quite hard}
-
-Another substantial advantage of our approach is that the simulated
-mutations are stored directly in the output data format with
-a defined API. Although
-Pyvolve and Phastsim are implemented in Python, neither provide
-programatic access to the simulated output, outputting instead
-to a series of files which must subsequently be parsed.
-See the Data Model section for more details and discussion.
-
-Things we can do: future work will need to do things like
-Dawg~\citep{cartwright2005dna} and to implement models and
-indels~\citep{fletcher2009indelible}.
 
 \subsection*{Simulation interface}
 
@@ -753,82 +859,6 @@ command line interface to support existing workflows, and the
 \texttt{msp} program that supports specifying demographic models in
 Demes format~\citep{gower2021demes} from the command line.
 
-
-\subsection*{Data interchange and interoperability}
-The point of simulations is to generate data and the efficiency with
-which simulated data can be incorporated into an overall application
-is an important---if often overlooked---issue.
-For example, Approximate Bayesian Computation
-(ABC)~\citep{beaumont2002approximate,csillery2010approximate,wegmann2010abctoolbox}
-and more recent machine learning
-methods~\citep{sheehan2016deep,schrider2018supervised,flagel2019unreasonable}
-perform population genetic inference by using large numbers of
-simulations as training data. Clearly, simulation efficiency is
-crucial since the size and number of simulations that can be performed determines
-the depth to which the model and parameter space can be sampled from.
-Equally important,
-however, is the efficiency with which the simulation results can be
-transformed into the specific input required by the inference method.
-In the case of ABC, this is usually a set of summary statistics of the sequence data.
-Modern approaches such as
-ABC-RF~\citep{raynal2019abc,pudlo2016abc} and
-ABC-NN~\citep{csillery2012abc,blum2010abc} can accommodate large numbers of user-specified statistics that are individually weakly informative,
-but jointly close to sufficient for the desired model or parameter.
-However, the computational resources needed to calculate these statistics can be even
-greater than those used to generate the simulated datasets.
-Older software such as DIYABC~\citep{cornuet2008inferring}
-or PopABC~\citep{lopes2009popabc} avoid this bottleneck by
-developing their own specialised simulators, tightly integrating them
-with the inference method. While this is certainly more efficient,
-there is a great deal of duplication of effort and significant
-room for error.
-As ABC inference has become useful in an ever-widening range of applications,
-these all-in-one methods risk falling behind if they do not allow users to explore
-the models and statistics of most interest.
-
-\jkcomment{Stuff to cover}
-\begin{itemize}
-
-\item The core problem is that the field lacks an efficient mechanism for
-    interchanging simulated data, and so developers are forced to choose
-    between efficiency and duplication of effort.
-
-\item What are the output formats of simulators? Newick, or sequence data
-    basically. What's the problem with this? We don't have mutations.
-    Much more efficient to have the tree and mutations than the
-    sequence data. Fundamentally, the output of coalescent simulations
-    should be trees, otherwise we are throwing a lot of information
-    away.
-
-\item Side note somewhere: with efficient access to branch length
-    statistics~\citep{ralph2019efficiently}, maybe we don't need to
-    simulate mutations at all.
-[GT: I'm not so sure about this -- the desired statistics/summaries
-must be calculated on the observed dataset as well as on the many
-simulated datasets.
-Unless the observed dataset is stored as a tree sequence,
-(because it has been through tsinfer, for example),
-it's not clear how branch or node stats could be calculated
-from it.
-]
-
-\item Msprime uses the \tskit\ library~\citep{tskit2021tskit}, which provides
-    extremely efficient interchange and data processing. A quick example
-    of how efficient.
-
-\item Tskit has facilited unprecedented interoperability between simulators:
-    Forward simulations can also use tree
-    sequences~\citep{kelleher2018efficient,haller2018tree}. In particular, SLiM
-    3.0~\citep{haller2019slim} and fwdpp~\citep{thornton2014cpp} can now output
-    tree sequences. Msprime can take tree sequences simulated by these forward
-    simulators as input and complete the simulation (``recapitation'').
-    See \cite{haller2018tree} for more details.
-
-\item Recently, Phastsim/USHER~\cite{demaio2021phastsim,turakhia2021ultrafast}
-    have used this idea of storing the
-    tree plus mutations, but approach is crude compared to tskit.
-
-\end{itemize}
 
 \subsection*{Development model}
 The community development process for \msprime\ is enabled by following an

--- a/paper.tex
+++ b/paper.tex
@@ -248,73 +248,79 @@ representation~\citep{ralph2020efficiently}.
 \jkcomment{Mention Phastsim/USHER~\citep{demaio2021phastsim,turakhia2021ultrafast}
 here. Same basic idea, but much cruder.}
 
-\jkcomment{Make some sort of link here between this paper, which is
-about msprime simulations, but that we can't really disentangle
-simulations from their downstream processing.}
-The point of simulations is to generate data and the efficiency with
-which simulated data can be incorporated into an overall application
-is an important issue.
-For example, Approximate Bayesian Computation
+\jkcomment{We need a link paragraph here between what this paper is
+about (what we can simulate) and what the rest of this section is about
+(efficiently using the \emph{results} of simulations). This is where
+we should review the classical approaches. Then lead into the
+the discussion of why we need simulations to be efficiently processable,
+most importantly, in inference methods like ABC and ML.}
+
+The abilily to efficiently process simulation results is
+particularly important in simulation-based inference methods
+such as Approximate Bayesian Computation
 (ABC)~\citep{beaumont2002approximate,csillery2010approximate,wegmann2010abctoolbox}
-and more recent machine learning
-methods~\citep{sheehan2016deep,schrider2018supervised,flagel2019unreasonable}
-perform population genetic inference by using large numbers of
-simulations as training data. Clearly, simulation efficiency is
+and machine learning based
+approaches~\citep{sheehan2016deep,schrider2018supervised,flagel2019unreasonable,
+sanchez2020deep}. Clearly, simulation efficiency is
 crucial since the size and number of simulations that can be performed determines
 the depth to which the model and parameter space can be sampled from.
 Equally important,
 however, is the efficiency with which the simulation results can be
 transformed into the specific input required by the inference method.
-In the case of ABC, this is usually a set of summary statistics of the sequence data.
-Modern approaches such as
-ABC-RF~\citep{raynal2019abc,pudlo2016abc} and
-ABC-NN~\citep{csillery2012abc,blum2010abc} can accommodate large
-numbers of user-specified statistics that are individually weakly informative,
-but jointly close to sufficient for the desired model or parameter.
-However, the computational resources needed to calculate these statistics can be even
-greater than those used to generate the simulated datasets.
-Older software such as DIYABC~\citep{cornuet2008inferring}
-or PopABC~\citep{lopes2009popabc} avoid this bottleneck by
-developing their own specialised simulators, tightly integrating them
-with the inference method. While this is certainly more efficient,
+In the case of ABC, this is usually a set of summary statistics of the sequence
+data, and methods avoid the bottleneck of parsing
+text-based file formats to compute these statistics
+by either developing their own
+simulators~\citep[e.g.][]{cornuet2008inferring,lopes2009popabc}
+or creating forked versions of existing
+simulators~\cite[e.g.][]{pavlidis2010msabc,quinto2018modeling},
+tightly integrated with the inference method.
+While this is certainly more efficient,
 there is a great deal of duplication of effort and significant
-room for error.
-As ABC inference has become useful in an ever-widening range of applications,
-these all-in-one methods risk falling behind if they do not allow users to explore
-the models and statistics of most interest.
+room for error (and propagation of bugs).
+Modern approaches to ABC such as
+ABC-RF~\citep{raynal2019abc,pudlo2016abc} and
+ABC-NN~\citep{csillery2012abc,blum2010abc} use large
+numbers of weakly informative statistics,
+making the need to efficiently compute statistics from simulation
+results even more acute.
 
-\jkcomment{Other potential stuff to cover}
-\begin{itemize}
+Classical text based output formats like \ms\ are inefficient to process,
+but also lacking a great deal of important information.
+The tree-by-tree topology information output by simulators in Newick
+format lacks any concept of node (in the tree sequence sense) identity,
+and means that we cannot reliably infer information about ancestors
+from the output \jkcomment{Also there's the inherent limitation of
+newick using branch lenghts; I think there's some citations for
+the issues this causes. Probably in the original msprime paper.}.
+This has been worked around by using approximate definitions of
+concepts like identity by descent (cite carmi paper) \jkcomment{
+any other computation methods developed just to work around the
+crappiness of ms output?}
+Numerous forks
+of simulators have been created to access information not provided
+in the output. For example, \ms\  has been forked to
+output information about migrating segments~\citep{rosenzweig2016powerful},
+information about ancestral lineages~\citep{chen2013asymptotic},
+% Any more?
+and \ms's fork \texttt{msHOT}~\citep{hellenthal2007mshot},
+has in turn been forked to output information on local
+ancestry~\citep{racimo2017archaic}.
+All of this information
+is either directly available by default in \msprime, or can be optionally
+stored via options such as \texttt{record\_migrations} or
+\texttt{record\_full\_arg} (see the \nameref{sec-arg} section) and
+can be efficiently and conveniently processed via \tskit\ APIs.
 
-\item What are the output formats of simulators? Newick, or sequence data
-    basically. What's the problem with this? We don't have mutations.
-    Much more efficient to have the tree and mutations than the
-    sequence data. Fundamentally, the output of coalescent simulations
-    should be trees, otherwise we are throwing a lot of information
-    away.
 
-\item Lots of examples of papers where people have been forced to
-    create a modified fork of some simulator so that they can get
-    access to some internal details, not exposed by the simulators
-    interface. Tree sequences provide a complete record of the
-    ancestral process, so we can do things like compute IBD
-    segments and introgressed tracts directly on the output. See
-    also ARG section for recording more information, though.
-
-\item Side note somewhere: with efficient access to branch length
-    statistics~\citep{ralph2020efficiently}, maybe we don't need to
-    simulate mutations at all. (not in the ABC context, but elsewhere)
-
-\item Tskit has facilited unprecedented interoperability between simulators:
-    Forward simulations can also use tree
-    sequences~\citep{kelleher2018efficient,haller2018tree}. In particular, SLiM
-    3.0~\citep{haller2019slim} and fwdpp~\citep{thornton2014cpp} can now output
-    tree sequences. Msprime can take tree sequences simulated by these forward
-    simulators as input and complete the simulation (``recapitation'').
-    See \cite{haller2018tree} for more details.
-    (Although, this could be a discussion point?)
-
-\end{itemize}
+\jkcomment{Fit this in somewhere? Or maybe it should be a discussion point?}
+Tskit has facilited unprecedented interoperability between simulators:
+Forward simulations can also use tree
+sequences~\citep{kelleher2018efficient,haller2018tree}. In particular, SLiM
+3.0~\citep{haller2019slim} and fwdpp~\citep{thornton2014cpp} can now output
+tree sequences. Msprime can take tree sequences simulated by these forward
+simulators as input and complete the simulation (``recapitation'').
+See \cite{haller2018tree} for more details.
 
 
 \subsection*{Finite sites mutations}

--- a/paper.tex
+++ b/paper.tex
@@ -136,27 +136,32 @@ This paper marks the release of \msprime\ 1.0.
 
 \section*{Results}
 
-\jkcomment{We should trim this down quite a bit - all we want to do is some basic
-roadmapping, like, we discuss the underlying tree sequence object,
+\jkcomment{Give a quick roadmap,
+like, we discuss the underlying tree sequence object,
 then mutations (because it's quite separate from the rest)
 and then a bunch of new features for ancestry simulation. There's no
 point in listing it out section by section.}
-In this section we describe the main features of \msprime\ 1.0. Methodologically,
-there exists a logical separation between simulating coalescent genealogies and
-adding neutral mutations onto these genealogies. Simulating genetic ancestry
-requires methods that model the underlying reproductive process (e.g. Moran,
-Wright-Fisher, etc.) as well as accounting for recombination of various sorts
-(including gene conversion), demography, and selection. These methods are
-discussed in the first N subsections below. One of the strengths of the
-approach taken in msprime is that neutral mutations can be retrospectively
-added to simulated genealogies. Methods to generate mutations, and thereby
-generate genetic variation, are therefore discussed in a separate and subsequent
-subsection. Finally, we describe the \msprime\ API, which is designed to enforce
-the distinction between simulating genealogies and mutations; discuss the
-interoperability provided by the use of \tskit\, the tree sequence toolkit;
-and highlight the open source development process which allows for \msprime\
-to be extended by addition of new features while ensuring robustness and
-maintainability of the core codebase.
+
+% JK: commented out this text as it's misleading and would confuse
+% people. We should adapt it when writing the roadmap when the structure
+% has settled down.
+
+% In this section we describe the main features of \msprime\ 1.0. Methodologically,
+% there exists a logical separation between simulating coalescent genealogies and
+% adding neutral mutations onto these genealogies. Simulating genetic ancestry
+% requires methods that model the underlying reproductive process (e.g. Moran,
+% Wright-Fisher, etc.) as well as accounting for recombination of various sorts
+% (including gene conversion), demography, and selection. These methods are
+% discussed in the first N subsections below. One of the strengths of the
+% approach taken in msprime is that neutral mutations can be retrospectively
+% added to simulated genealogies. Methods to generate mutations, and thereby
+% generate genetic variation, are therefore discussed in a separate and subsequent
+% subsection. Finally, we describe the \msprime\ API, which is designed to enforce
+% the distinction between simulating genealogies and mutations; discuss the
+% interoperability provided by the use of \tskit\, the tree sequence toolkit;
+% and highlight the open source development process which allows for \msprime\
+% to be extended by addition of new features while ensuring robustness and
+% maintainability of the core codebase.
 
 \subsection*{Tree sequences}
 One of the key reasons for \msprime's significiant performance advantage

--- a/paper.tex
+++ b/paper.tex
@@ -118,7 +118,7 @@ This data structure has
 also lead to major advances in forwards-time
 simulation~\citep{kelleher2018efficient,haller2018tree},
 ancestry inference~\citep{kelleher2019inferring,wohns2021unified}
-and calculation of population genetic statistics~\citep{ralph2019efficiently}.
+and calculation of population genetic statistics~\citep{ralph2020efficiently}.
 Through a rigorous open-source community development process,
 \msprime\ has gained a large number of features since its introduction,
 making a highly efficient and flexible platform for population
@@ -163,8 +163,8 @@ point in listing it out section by section.}
 % to be extended by addition of new features while ensuring robustness and
 % maintainability of the core codebase.
 
-\label{sec-ts}
 \subsection*{Tree sequences}
+\label{sec-ts}
 One of the key reasons for \msprime's significiant performance advantage
 over other simulators is its usage of the ``succinct tree sequence''
 (usually, tree sequence) data stucture and the supporting \tskit\
@@ -172,6 +172,9 @@ library~\citep{tskit2021tskit}.
 While a full discussion of tree sequences and the capabilities
 of \tskit\ is beyond the scope of this article, we briefly summarise
 here.
+\jkcomment{We need to mention that tree sequences and tskit are
+derived from the 2016 paper and have been extracted from msprime
+into a separate C/Python library.}
 
 \begin{figure}
 \begin{center}
@@ -209,8 +212,6 @@ is a generalisation from the original concept  of
 ``coalescence records''~\citep{kelleher2016efficient}, and
 is the key to the efficiency of tree sequences.
 \jkcomment{Summarise and add references?}
-As discussed in the \ref{sec-mutations} section, tree sequences
-can also store genetic variation data very efficiently.
 
 The term Ancestral Recombination Graph (ARG) is often understood
 to mean the complete record of a sample's genetic
@@ -224,8 +225,32 @@ ARGs without loss of information---although we do not store
 the additional ARG information by default
 in \msprime\ because the minimal tree sequence encoding is
 much more concise (see the \nameref{sec-arg} section for more details).
+It should be noted that, despite efforts to
+standardise~\citep{cardona2008extended,mcgill2013graphml}, there is
+no shared format for interchanging ARG data, and no supporting software
+libraries.
 
+Tree sequences encode a complete and concise description of a set of sampled
+chromosome's genetic ancestry, and they can also efficiently represent
+the genetic variation (extant and ancestral).
+As illustrated in Fig.~\ref{fig-ts-example}, the \tskit\ tree
+sequence encoding includes \emph{site} and \emph{mutation} tables. Each
+row in the site table represents some position along the genome, and
+each row in the mutation table represents a change of allelic state
+at a particular site and node. Since the number of mutations is typically
+small, we can usually store the genetic variation for a given variant
+site in constant space. This approach of storing the genetic variation
+via the genetic ancestry is both very concise and extremely efficient
+to process---for example, computing Tajima's $D$ using \tskit\
+is several orders of magnitude faster for large sample sizes than
+efficient libraries working with the variant matrix
+representation~\citep{ralph2020efficiently}.
+\jkcomment{Mention Phastsim/USHER~\citep{demaio2021phastsim,turakhia2021ultrafast}
+here. Same basic idea, but much cruder.}
 
+\jkcomment{Make some sort of link here between this paper, which is
+about msprime simulations, but that we can't really disentangle
+simulations from their downstream processing.}
 The point of simulations is to generate data and the efficiency with
 which simulated data can be incorporated into an overall application
 is an important issue.
@@ -258,12 +283,8 @@ As ABC inference has become useful in an ever-widening range of applications,
 these all-in-one methods risk falling behind if they do not allow users to explore
 the models and statistics of most interest.
 
-\jkcomment{Stuff to cover}
+\jkcomment{Other potential stuff to cover}
 \begin{itemize}
-
-\item The core problem is that the field lacked an efficient mechanism for
-    interchanging simulated data, and so developers were forced to choose
-    between efficiency and duplication of effort.
 
 \item What are the output formats of simulators? Newick, or sequence data
     basically. What's the problem with this? We don't have mutations.
@@ -281,12 +302,8 @@ the models and statistics of most interest.
     also ARG section for recording more information, though.
 
 \item Side note somewhere: with efficient access to branch length
-    statistics~\citep{ralph2019efficiently}, maybe we don't need to
+    statistics~\citep{ralph2020efficiently}, maybe we don't need to
     simulate mutations at all. (not in the ABC context, but elsewhere)
-
-\item Msprime uses the \tskit\ library~\citep{tskit2021tskit}, which provides
-    extremely efficient interchange and data processing. A quick example
-    of how efficient.
 
 \item Tskit has facilited unprecedented interoperability between simulators:
     Forward simulations can also use tree
@@ -297,15 +314,11 @@ the models and statistics of most interest.
     See \cite{haller2018tree} for more details.
     (Although, this could be a discussion point?)
 
-\item Recently, Phastsim/USHER~\cite{demaio2021phastsim,turakhia2021ultrafast}
-    have used this idea of storing the
-    tree plus mutations, but approach is crude compared to tskit.
-
 \end{itemize}
 
 
-\label{sec-mutations}
 \subsection*{Finite sites mutations}
+\label{sec-mutations}
 Version 0.x of \texttt{msprime} provided a very simple mutation model,
 supporting only the infinite sites model.
 With version 1.0, we now support a large number of mutation models,

--- a/paper.tex
+++ b/paper.tex
@@ -183,6 +183,7 @@ into a separate C/Python library.}
 \caption{\label{fig-ts-example} Example tree sequence.
 An example tree sequence describing genealogies and genotypes
 for four samples at ten sites.
+Figure based on~\citet{kelleher2018efficient}.
 }
 \end{figure}
 


### PR DESCRIPTION
This changes the structure of the Result section a little, by creating a "Tree sequences" section right at the top and moving the content that was in the "data interchange" section in here, with an example tree sequence figure.

I've also moved the "Mutations" section up to the top, because I think it'll get lost in all the ancestry stuff otherwise, and this makes it easier to emphasis the distinction between mutations and ancestry. I've made a note that we should update the rroadmapping at the top, which is out of date.

@petrelharp - is it OK to use your example tree sequence figure here like this?

What do we think of the structure?
