### PR TITLE
fastSimBac evaluation

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -31,6 +31,11 @@
 }
 % \address{
 
+%%Affiliations:
+% Franz Baumdicker:
+% Cluster of Excellence "Controlling Microbes to Fight Infections", Mathematical and Computational Population Genetics, University of Tübingen, Germany
+
+
 % \section*{Contact:} \href{jerome.kelleher@bdi.ox.ac.uk}{jerome.kelleher@bdi.ox.ac.uk}
 
 \maketitle
@@ -1057,6 +1062,8 @@ Also \stdpopsim\ is cool~\citep{adrion2020community}
 JK is supported by the Robertson Foundation.
 Jere Koskela is supported in part by EPSRC grant EP/R044732/1.
 ADK was supported by NIH awards R01GM117241 and R01HG010774.
+Franz Baumdicker is funded by the Deutsche Forschungsgemeinschaft
+EXC 2064/1 -- Project number 390727645, and EXC 2124 -- Project number 390838134.
 
 \bibliographystyle{plainnat}
 \bibliography{paper}


### PR DESCRIPTION
After some very helpful comments from Nicola De Maio I found the issue with the fastSimBac number of trees.
Instead of comparing it to the number of breakpoints, as we do for SimBac, we need to compare to the number of trees.
However, this only works with the newick output of fastSimBac. The internal number of trees in fastSimBac does neither match the msprime number of trees nor the number of breakpoints.

The evaluation is thus now fine and we can run the benchmarks with the current parameters.

In addition, I added my funding resources and affiliation to the manuscript.