### PR TITLE
small typo fixes

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -1343,7 +1343,7 @@ The coalescent is an idealised model and makes many simplifying assumptions,
 but it is often surprisingly robust to violations of these
 assumptions~\citep{wakeley2012gene}. One situation in which the
 model does break down is the combination of large sample size
-and with long recombining genomes, where the large
+and long recombining genomes, where the large
 number of recombination events in the recent past results in
 more than the biologically possible $2^t$ ancestors in
 $t$ diploid generations~\citep{nelson2020accounting}.
@@ -1433,7 +1433,7 @@ lines of Python, with suites of 122 C tests (7K lines of code) and
 automatically on different operating systems on each pull request
 (where a contributor proposes a code change), using standard Continuous
 Integration (CI) methodology. Other CI services check code formatting
-and for common errors, as well as producing reports on the level of
+and for common errors, as well as produce reports on the level of
 test coverage, e.g., pinpointing areas where additional unit tests may
 be required.
 
@@ -1496,7 +1496,7 @@ it also represents a missed opportunity to invest as a community
 in shared infrastructure and mentorship in good software development practice.
 
 % THERE IS A BETTER WAY!!!
-Scientific software is vital apparatus, and must be engineered
+Scientific software is a vital apparatus, and must be engineered
 to a high quality if we are to trust its results. There is a growing
 realisation across the sciences \citet[OTHER CITATIONS]{siepel2019challenges}
 % Maybe cite: https://www.biorxiv.org/content/10.1101/092205v3
@@ -1511,7 +1511,7 @@ established development practices and infrastructure.
 % PLR- personally I have learned SO MUCH, and I'm passing it on to others
 Software development in a welcoming community,
 with mentorship by experienced developers,
-is a hugely useful experience for many users,
+is a hugely useful experience for many users.
 The skills that contributors learn
 can lead to greatly increased productivity in subsequent
 work (e.g., through more reliable code and better debugging skills).

--- a/paper.tex
+++ b/paper.tex
@@ -1433,7 +1433,7 @@ lines of Python, with suites of 122 C tests (7K lines of code) and
 automatically on different operating systems on each pull request
 (where a contributor proposes a code change), using standard Continuous
 Integration (CI) methodology. Other CI services check code formatting
-and for common errors, as well as produce reports on the level of
+and for common errors, as well as producing reports on the level of
 test coverage, e.g., pinpointing areas where additional unit tests may
 be required.
 
@@ -1496,7 +1496,7 @@ it also represents a missed opportunity to invest as a community
 in shared infrastructure and mentorship in good software development practice.
 
 % THERE IS A BETTER WAY!!!
-Scientific software is a vital apparatus, and must be engineered
+Scientific software is vital apparatus, and must be engineered
 to a high quality if we are to trust its results. There is a growing
 realisation across the sciences \citet[OTHER CITATIONS]{siepel2019challenges}
 % Maybe cite: https://www.biorxiv.org/content/10.1101/092205v3


### PR DESCRIPTION
A few typos I just caught. Also, examples using e.g. are inconsistently parenthesized throughout, but I'm not sure what the preferred style is.